### PR TITLE
Feat: #10 사진 분류 뷰 UI 구현, 사진 데이터 관리 로직 구현

### DIFF
--- a/HonestHouse/HonestHouse/Sources/App/HonestHouseApp.swift
+++ b/HonestHouse/HonestHouse/Sources/App/HonestHouseApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct HonestHouseApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            PhotoSelectionView()
         }
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Core/Model/Photo.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Model/Photo.swift
@@ -1,0 +1,43 @@
+//
+//  Photo.swift
+//  HonestHouse
+//
+//  Created by Rama on 10/23/25.
+//
+
+import SwiftUI
+
+struct Photo: Identifiable, SelectableItem {
+    let id = UUID()
+    var url: String
+    var mediaType: MediaType
+    
+    var thumbnailURL: String? {
+        "\(url)?kind=thumbnail"
+    }
+    
+    init(url: String) {
+        self.url = url
+        let fileExtension = (url as NSString).pathExtension.lowercased()
+        switch fileExtension {
+        case "jpeg":
+            self.mediaType = .jpeg
+        case "cr2":
+            self.mediaType = .cr2
+        case "cr3":
+            self.mediaType = .cr3
+        default:
+            self.mediaType = .unknown
+        }
+    }
+}
+
+extension Photo {
+    static func mockPhotos(count: Int) -> [Photo] {
+        let baseURL = "https://raw.githubusercontent.com/Rama-Moon/MockImage/main"
+        
+        return (1...count).map { index in
+            Photo(url: "\(baseURL)/photo\(index).JPG")
+        }
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/Core/Model/Photo.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Model/Photo.swift
@@ -16,6 +16,10 @@ struct Photo: Identifiable, SelectableItem {
         "\(url)?kind=thumbnail"
     }
     
+    var displayURL: String? {
+        "\(url)?kind=display"
+    }
+    
     init(url: String) {
         self.url = url
         let fileExtension = (url as NSString).pathExtension.lowercased()

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/SelectionGridCellView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/SelectionGridCellView.swift
@@ -1,5 +1,5 @@
 //
-//  GridCellView.swift
+//  SelectionGridCellView.swift
 //  HonestHouse
 //
 //  Created by Rama on 10/22/25.
@@ -8,7 +8,7 @@
 import SwiftUI
 import Kingfisher
 
-struct PhotoGridCellView: View {
+struct SelectionGridCellView: View {
     let photo: Photo
     let isSelected: Bool
     let onTap: () -> Void

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/SelectionGridCellView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/SelectionGridCellView.swift
@@ -11,7 +11,7 @@ import Kingfisher
 struct SelectionGridCellView: View {
     let photo: Photo
     let isSelected: Bool
-    let onTap: () -> Void
+    let onTapSelectionGridCell: () -> Void
     
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
@@ -23,7 +23,7 @@ struct SelectionGridCellView: View {
                     .overlay(isSelected ? Color.black.opacity(0.3) : Color.clear)
             }
             
-            Button(action: onTap) {
+            Button(action: onTapSelectionGridCell) {
                 if isSelected {
                     ZStack {
                         Circle()

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/SelectionGridCellView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/SelectionGridCellView.swift
@@ -8,15 +8,15 @@
 import SwiftUI
 import Kingfisher
 
-struct SelectionGridCellView: View {
-    let photo: Photo
+struct SelectionGridCellView<Item: SelectableItem>: View {
+    let item: Item
     let isSelected: Bool
     let onTapSelectionGridCell: () -> Void
     
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
-            NavigationLink(destination: PhotoSelectionDetailView(photo: photo)) {
-                KFImage(URL(string: photo.url))
+            NavigationLink(destination: PhotoSelectionDetailView(item: item)) {
+                KFImage(URL(string: item.url))
                     .resizable()
                     .aspectRatio(1, contentMode: .fill)
                     .clipped()

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Protocol/MediaType.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Protocol/MediaType.swift
@@ -1,0 +1,15 @@
+//
+//  MediaType.swift
+//  HonestHouse
+//
+//  Created by Rama on 10/23/25.
+//
+
+import Foundation
+
+enum MediaType {
+    case jpeg
+    case cr2 //RAW
+    case cr3 //RAW
+    case unknown
+}

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Protocol/SelectableItem.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Protocol/SelectableItem.swift
@@ -11,4 +11,5 @@ protocol SelectableItem: Identifiable {
     var url: String { get }
     var mediaType: MediaType { get }
     var thumbnailURL: String? { get }
+    var displayURL: String? { get }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Protocol/SelectableItem.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Protocol/SelectableItem.swift
@@ -1,0 +1,14 @@
+//
+//  SelectableItem.swift
+//  HonestHouse
+//
+//  Created by Rama on 10/23/25.
+//
+
+import Foundation
+
+protocol SelectableItem: Identifiable {
+    var url: String { get }
+    var mediaType: MediaType { get }
+    var thumbnailURL: String? { get }
+}

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosDetailView.swift
@@ -9,13 +9,17 @@ import SwiftUI
 import Kingfisher
 
 struct GroupedPhotosDetailView: View {
+    let groupedPhotos: GroupedPhotos
+    
     var body: some View {
-        VStack {
-            KFImage(URL(string: "https://raw.githubusercontent.com/Rama-Moon/MockImage/main/photo1.JPG"))
-                .frame(maxWidth: .infinity)
-                .imageScale(.large)
-                .padding(16)
+        TabView {
+            ForEach(groupedPhotos.photos) { photo in
+                KFImage(URL(string: photo.url))
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            }
         }
-
+        .tabViewStyle(.page)
+        .indexViewStyle(.page(backgroundDisplayMode: .always))
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosDetailView.swift
@@ -15,35 +15,44 @@ struct GroupedPhotosDetailView: View {
     
     var body: some View {
         TabView {
-            ForEach(groupedPhotos.photos) { photo in
-                ZStack(alignment: .bottomTrailing) {
-                    KFImage(URL(string: photo.url))
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                    
-                    Button(action: { onTapGroupedPhoto(photo) }) {
-                        if finalSelectedPhotos.contains(where: { $0.id == photo.id }) {
-                            ZStack {
-                                Circle()
-                                    .fill(Color.white)
-                                    .frame(width: 24, height: 24)
-                                
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundColor(.blue)
-                                    .font(.system(size: 24))
-                            }
-                        } else {
-                            Circle()
-                                .fill(Color.white)
-                                .frame(width: 24, height: 24)
-                        }
-                    }
-                    .frame(width: 44, height: 44)
-                    .contentShape(Rectangle())
-                }
-            }
+            groupedImagesView()
         }
         .tabViewStyle(.page)
         .indexViewStyle(.page(backgroundDisplayMode: .always))
+    }
+    
+    //MARK: View Component
+    private func groupedImagesView() -> some View {
+        ForEach(groupedPhotos.photos) { photo in
+            ZStack(alignment: .bottomTrailing) {
+                KFImage(URL(string: photo.url))
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                
+                selectionButtonView(photo: photo)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+        }
+    }
+    
+    private func selectionButtonView(photo: Photo) -> some View {
+        Button(action: { onTapGroupedPhoto(photo) }) {
+            if finalSelectedPhotos.contains(where: { $0.id == photo.id }) {
+                ZStack {
+                    Circle()
+                        .fill(Color.white)
+                        .frame(width: 24, height: 24)
+                    
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.blue)
+                        .font(.system(size: 24))
+                }
+            } else {
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 24, height: 24)
+            }
+        }
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosDetailView.swift
@@ -6,12 +6,16 @@
 //
 
 import SwiftUI
+import Kingfisher
 
 struct GroupedPhotosDetailView: View {
     var body: some View {
-        Image(systemName: "globe")
-            .imageScale(.large)
-            .foregroundStyle(.tint)
-        Text("Hello, world!")
+        VStack {
+            KFImage(URL(string: "https://raw.githubusercontent.com/Rama-Moon/MockImage/main/photo1.JPG"))
+                .frame(maxWidth: .infinity)
+                .imageScale(.large)
+                .padding(16)
+        }
+
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosDetailView.swift
@@ -10,13 +10,37 @@ import Kingfisher
 
 struct GroupedPhotosDetailView: View {
     let groupedPhotos: GroupedPhotos
+    let finalSelectedPhotos: [Photo]
+    let onTapGroupedPhoto: (Photo) -> Void
     
     var body: some View {
         TabView {
             ForEach(groupedPhotos.photos) { photo in
-                KFImage(URL(string: photo.url))
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
+                ZStack(alignment: .bottomTrailing) {
+                    KFImage(URL(string: photo.url))
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                    
+                    Button(action: { onTapGroupedPhoto(photo) }) {
+                        if finalSelectedPhotos.contains(where: { $0.id == photo.id }) {
+                            ZStack {
+                                Circle()
+                                    .fill(Color.white)
+                                    .frame(width: 24, height: 24)
+                                
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundColor(.blue)
+                                    .font(.system(size: 24))
+                            }
+                        } else {
+                            Circle()
+                                .fill(Color.white)
+                                .frame(width: 24, height: 24)
+                        }
+                    }
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+                }
             }
         }
         .tabViewStyle(.page)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosView.swift
@@ -8,12 +8,40 @@
 import SwiftUI
 
 struct GroupedPhotosView: View {
-    @Binding var selectedPhotos: [Photo]
+    @State private var vm = GroupedPhotosViewModel()
+    
+    var columns: [GridItem] {
+        Array(repeating: GridItem(.flexible()), count: 2)
+    }
     
     var body: some View {
-        Image(systemName: "globe")
-            .imageScale(.large)
-            .foregroundStyle(.tint)
-        Text("Hello, world!")
+        NavigationStack {
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 10) {
+                    // TODO: Vision 사용한 그룹핑 이후 그룹에 대해 for문 순회하게 수정
+                    ForEach(vm.selectedPhotos) { photo in
+                        groupedPhotosGridCell(groupedPhotos: photo)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 32)
+            }
+        }
     }
+    
+    private func groupedPhotosGridCell(groupedPhotos: Photo) -> some View {
+        NavigationLink(destination: GroupedPhotosDetailView()) {
+            Image(systemName: "checkmark")
+                .font(.system(size: 24))
+                .foregroundColor(.white)
+                .padding(.horizontal, 68)
+                .padding(.vertical, 52)
+                .background(Color.blue)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+}
+
+#Preview {
+    GroupedPhotosView()
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosView.swift
@@ -29,7 +29,7 @@ struct GroupedPhotosView: View {
             ScrollView {
                 LazyVGrid(columns: columns, spacing: 10) {
                     ForEach(vm.groupedPhotos) { group in
-                        groupedPhotosGridCell(group: group)
+                        groupedPhotosGridCellView(group: group)
                     }
                 }
                 .padding(.horizontal, 16)
@@ -38,12 +38,12 @@ struct GroupedPhotosView: View {
         }
     }
     
-    private func groupedPhotosGridCell(group: GroupedPhotos) -> some View {
+    private func groupedPhotosGridCellView(group: GroupedPhotos) -> some View {
         NavigationLink(
             destination: GroupedPhotosDetailView(
                 groupedPhotos: group,
                 finalSelectedPhotos: vm.selectedPhotosInGroup,
-                onTapGroupedPhoto: toggleGroupedPhoto)
+                onTapGroupedPhoto: toggleGroupedPhotoView)
         ) {
             if let firstPhoto = group.photos.first {
                 KFImage(URL(string: firstPhoto.url))
@@ -67,7 +67,7 @@ struct GroupedPhotosView: View {
         }
     }
     
-    private func toggleGroupedPhoto(for photo: Photo) {
+    private func toggleGroupedPhotoView(for photo: Photo) {
         if let index = vm.selectedPhotosInGroup.firstIndex(where: { $0.url == photo.url}) {
             vm.selectedPhotosInGroup.remove(at: index)
         } else {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosView.swift
@@ -6,21 +6,30 @@
 //
 
 import SwiftUI
+import Kingfisher
+
+struct GroupedPhotos: Identifiable {
+    let id = UUID()
+    let photos: [Photo]
+}
 
 struct GroupedPhotosView: View {
-    @State private var vm = GroupedPhotosViewModel()
+    @State private var vm: GroupedPhotosViewModel
     
     var columns: [GridItem] {
         Array(repeating: GridItem(.flexible()), count: 2)
+    }
+    
+    init(selectedPhotos: [Photo]) {
+        _vm = State(wrappedValue: GroupedPhotosViewModel(selectedPhotos: selectedPhotos))
     }
     
     var body: some View {
         NavigationStack {
             ScrollView {
                 LazyVGrid(columns: columns, spacing: 10) {
-                    // TODO: Vision 사용한 그룹핑 이후 그룹에 대해 for문 순회하게 수정
-                    ForEach(vm.selectedPhotos) { photo in
-                        groupedPhotosGridCell(groupedPhotos: photo)
+                    ForEach(vm.groupedPhotos) { group in
+                        groupedPhotosGridCell(group: group)
                     }
                 }
                 .padding(.horizontal, 16)
@@ -29,19 +38,27 @@ struct GroupedPhotosView: View {
         }
     }
     
-    private func groupedPhotosGridCell(groupedPhotos: Photo) -> some View {
-        NavigationLink(destination: GroupedPhotosDetailView()) {
-            Image(systemName: "checkmark")
-                .font(.system(size: 24))
-                .foregroundColor(.white)
-                .padding(.horizontal, 68)
-                .padding(.vertical, 52)
-                .background(Color.blue)
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+    private func groupedPhotosGridCell(group: GroupedPhotos) -> some View {
+        NavigationLink(destination: GroupedPhotosDetailView(groupedPhotos: group)) {
+            if let firstPhoto = group.photos.first {
+                KFImage(URL(string: firstPhoto.url))
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 160, height: 120)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .overlay(
+                        ZStack(alignment: .topTrailing) {
+                            Text("\(group.photos.count)")
+                                .font(.caption)
+                                .fontWeight(.bold)
+                                .foregroundColor(.white)
+                                .padding(6)
+                                .background(Color.black.opacity(0.7))
+                                .clipShape(Circle())
+                                .padding(8)
+                        }
+                    )
+            }
         }
     }
-}
-
-#Preview {
-    GroupedPhotosView()
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosView.swift
@@ -39,7 +39,12 @@ struct GroupedPhotosView: View {
     }
     
     private func groupedPhotosGridCell(group: GroupedPhotos) -> some View {
-        NavigationLink(destination: GroupedPhotosDetailView(groupedPhotos: group)) {
+        NavigationLink(
+            destination: GroupedPhotosDetailView(
+                groupedPhotos: group,
+                finalSelectedPhotos: vm.selectedPhotosInGroup,
+                onTapGroupedPhoto: toggleGroupedPhoto)
+        ) {
             if let firstPhoto = group.photos.first {
                 KFImage(URL(string: firstPhoto.url))
                     .resizable()
@@ -59,6 +64,14 @@ struct GroupedPhotosView: View {
                         }
                     )
             }
+        }
+    }
+    
+    private func toggleGroupedPhoto(for photo: Photo) {
+        if let index = vm.selectedPhotosInGroup.firstIndex(where: { $0.url == photo.url}) {
+            vm.selectedPhotosInGroup.remove(at: index)
+        } else {
+            vm.selectedPhotosInGroup.append(photo)
         }
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionDetailView.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 import Kingfisher
 
-struct PhotoSelectionDetailView: View {
-    let photo: Photo
+struct PhotoSelectionDetailView<Item: SelectableItem>: View {
+    let item: Item
     
     var body: some View {
-            KFImage(URL(string: photo.url))
+            KFImage(URL(string: item.url))
                 .resizable()
                 .aspectRatio(contentMode: .fit)
     }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionDetailView.swift
@@ -12,10 +12,8 @@ struct PhotoSelectionDetailView: View {
     let photo: Photo
     
     var body: some View {
-        KFImage(URL(string: photo.url))
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .navigationTitle("사진 상세")
-            .navigationBarTitleDisplayMode(.inline)
+            KFImage(URL(string: photo.url))
+                .resizable()
+                .aspectRatio(contentMode: .fit)
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
@@ -25,7 +25,7 @@ struct PhotoSelectionView: View {
                     LazyVGrid(columns: columns, spacing: 2) {
                         ForEach(photos) { photo in
                             SelectionGridCellView(
-                                photo: photo,
+                                item: photo,
                                 isSelected: selectedPhotos.contains(where: { $0.url == photo.url }),
                                 onTapSelectionGridCell: { toggleGridCell(for: photo) }
                             )

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
@@ -55,6 +55,7 @@ struct PhotoSelectionView: View {
         }
     }
     
+    //TODO: ViewModel 생성 후 이동
     private func toggleGridCell(for photo: Photo) {
         if let index = selectedPhotos.firstIndex(where: { $0.url == photo.url }) {
             selectedPhotos.remove(at: index)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
@@ -37,7 +37,7 @@ struct PhotoSelectionView: View {
                 ScrollView {
                     LazyVGrid(columns: columns, spacing: 2) {
                         ForEach(photos) { photo in
-                            PhotoGridCellView(
+                            SelectionGridCellView(
                                 photo: photo,
                                 isSelected: selectedPhotos.contains(where: { $0.url == photo.url }),
                                 onTap: { toggleSelection(for: photo) }
@@ -50,7 +50,7 @@ struct PhotoSelectionView: View {
                 VStack {
                     Spacer()
                     // TODO: 사진이 한 장 이상 선택됐을 때 push 가능하게 수정
-                    NavigationLink(destination: GroupedPhotosView(selectedPhotos: $selectedPhotos)) {
+                    NavigationLink(destination: GroupedPhotosView()) {
                         Text("완료")
                             .font(.title3)
                             .frame(maxWidth: .infinity)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
@@ -8,19 +8,6 @@
 import SwiftUI
 import Kingfisher
 
-struct Photo: Identifiable {
-    let id = UUID()
-    var url: String
-    
-    static func mockPhotos(count: Int) -> [Photo] {
-        let baseURL = "https://raw.githubusercontent.com/Rama-Moon/MockImage/main"
-        
-        return (1...count).map { index in
-            Photo(url: "\(baseURL)/photo\(index).JPG")
-        }
-    }
-}
-
 struct PhotoSelectionView: View {
     let columnCount: Int = 3
     let photos = Photo.mockPhotos(count: 20)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
@@ -40,7 +40,7 @@ struct PhotoSelectionView: View {
                             SelectionGridCellView(
                                 photo: photo,
                                 isSelected: selectedPhotos.contains(where: { $0.url == photo.url }),
-                                onTap: { toggleSelection(for: photo) }
+                                onTapSelectionGridCell: { toggleGridCell(for: photo) }
                             )
                         }
                     }
@@ -68,7 +68,7 @@ struct PhotoSelectionView: View {
         }
     }
     
-    private func toggleSelection(for photo: Photo) {
+    private func toggleGridCell(for photo: Photo) {
         if let index = selectedPhotos.firstIndex(where: { $0.url == photo.url }) {
             selectedPhotos.remove(at: index)
         } else {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
@@ -50,7 +50,7 @@ struct PhotoSelectionView: View {
                 VStack {
                     Spacer()
                     // TODO: 사진이 한 장 이상 선택됐을 때 push 가능하게 수정
-                    NavigationLink(destination: GroupedPhotosView()) {
+                    NavigationLink(destination: GroupedPhotosView(selectedPhotos: photos)) {
                         Text("완료")
                             .font(.title3)
                             .frame(maxWidth: .infinity)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/ViewModel/GroupedPhotosViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/ViewModel/GroupedPhotosViewModel.swift
@@ -1,0 +1,10 @@
+//
+//  GroupedPhotosViewModel.swift
+//  HonestHouse
+//
+//  Created by Rama on 10/22/25.
+//
+
+import SwiftUI
+
+class GroupedPhotosViewModel { }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/ViewModel/GroupedPhotosViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/ViewModel/GroupedPhotosViewModel.swift
@@ -7,6 +7,21 @@
 
 import SwiftUI
 
+@Observable
 class GroupedPhotosViewModel {
     var selectedPhotos = Photo.mockPhotos(count: 20)
+    var groupedPhotos: [GroupedPhotos] = []
+    
+    init(selectedPhotos: [Photo]) {
+        self.selectedPhotos = selectedPhotos
+        groupPhotosTemporarily()
+    }
+    
+    func groupPhotosTemporarily() {
+        let chunkSize = 5
+        let chunks = stride(from: 0, to: selectedPhotos.count, by: chunkSize).map {
+            Array(selectedPhotos[$0..<min($0 + chunkSize, selectedPhotos.count)])
+        }
+        self.groupedPhotos = chunks.map { GroupedPhotos(photos: $0)}
+    }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/ViewModel/GroupedPhotosViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/ViewModel/GroupedPhotosViewModel.swift
@@ -9,18 +9,19 @@ import SwiftUI
 
 @Observable
 class GroupedPhotosViewModel {
-    var selectedPhotos = Photo.mockPhotos(count: 20)
+    var photosFromSelection = Photo.mockPhotos(count: 20)
     var groupedPhotos: [GroupedPhotos] = []
+    var selectedPhotosInGroup: [Photo] = []
     
     init(selectedPhotos: [Photo]) {
-        self.selectedPhotos = selectedPhotos
+        self.photosFromSelection = selectedPhotos
         groupPhotosTemporarily()
     }
     
     func groupPhotosTemporarily() {
         let chunkSize = 5
-        let chunks = stride(from: 0, to: selectedPhotos.count, by: chunkSize).map {
-            Array(selectedPhotos[$0..<min($0 + chunkSize, selectedPhotos.count)])
+        let chunks = stride(from: 0, to: photosFromSelection.count, by: chunkSize).map {
+            Array(photosFromSelection[$0..<min($0 + chunkSize, photosFromSelection.count)])
         }
         self.groupedPhotos = chunks.map { GroupedPhotos(photos: $0)}
     }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/ViewModel/GroupedPhotosViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/ViewModel/GroupedPhotosViewModel.swift
@@ -7,4 +7,6 @@
 
 import SwiftUI
 
-class GroupedPhotosViewModel { }
+class GroupedPhotosViewModel {
+    var selectedPhotos = Photo.mockPhotos(count: 20)
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #10 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 그룹핑 된 사진들 모음을 나타내는 뷰, 그룹핑 된 사진들 중 셀렉을 할 수 있는 뷰 UI를 구현
- 아카이빙에서 사용될 사진 객체의 확장자에 따른 추상화

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->
![Simulator Screen Recording - iPhone 17 - 2025-10-24 at 11 40 21](https://github.com/user-attachments/assets/bdaf60b5-14d3-4927-a3b3-b7bac868c9fa)

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 아카이빙에서 선택할 Content는 향후 다양한 파일 확장자를 가질 수도 있고 사진이 아닌 영상이 될 수도 있다고 생각했습니다.
- 그래서 인터페이스를 설계하고 세세한 구현은 구현체에서 담당하도록 하여 확장한 가능한 설계를 고려했습니다.
(https://www.notion.so/295e807ed19580fc8434d876fd9f7521?source=copy_link)

---