### PR TITLE
Refactor: #37 getContentsList API를 chunk형태로 받아오기

### DIFF
--- a/HonestHouse/HonestHouse/Sources/Core/Model/Photo.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Model/Photo.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Photo: Identifiable, Equatable, Hashable, SelectableItem {
+struct Photo: Identifiable, SelectableItem {
     let id = UUID()
     var url: String
     var mediaType: MediaType
@@ -36,6 +36,20 @@ struct Photo: Identifiable, Equatable, Hashable, SelectableItem {
     }
 }
 
+// MARK: - Equatable & Hashable Conformance
+extension Photo: Equatable, Hashable {
+    /// URL을 기준으로 동일성 비교 (UUID는 무시)
+    static func == (lhs: Photo, rhs: Photo) -> Bool {
+        lhs.url == rhs.url && lhs.mediaType == rhs.mediaType
+    }
+    
+    /// URL을 기반으로 hash 생성 (UUID는 무시)
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(url)
+        hasher.combine(mediaType)
+    }
+}
+
 extension Photo {
     static func mockPhotos(count: Int) -> [Photo] {
         let baseURL = "https://raw.githubusercontent.com/Rama-Moon/MockImage/main"
@@ -45,3 +59,4 @@ extension Photo {
         }
     }
 }
+

--- a/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.7. ImageOperations/ImageOperationsTarget.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.7. ImageOperations/ImageOperationsTarget.swift
@@ -11,7 +11,7 @@ import Moya
 enum ImageOperationsTarget {
     case getStorageList
     case getDirectoryList(String)
-    case getContentList(String, String, String, String, Int)
+    case getContentList(String, String, String, String, String)
 }
 
 extension ImageOperationsTarget: BaseTargetType {
@@ -40,11 +40,11 @@ extension ImageOperationsTarget: BaseTargetType {
         case .getStorageList, .getDirectoryList:
             return .requestPlain
             
-        case .getContentList(_, _, let type, let kind, let page):
+        case .getContentList(_, _, let type, let kind, let order):
             let parameters: [String : Any] = [
                 "type" : type,
                 "kind" : kind,
-                "page" : page
+                "order" : order
             ]
             return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
         }

--- a/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.7. ImageOperations/ImageOperationsTarget.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.7. ImageOperations/ImageOperationsTarget.swift
@@ -11,7 +11,7 @@ import Moya
 enum ImageOperationsTarget {
     case getStorageList
     case getDirectoryList(String)
-    case getContentList(String, String, String, String, String)
+//    case getContentList(String, String, String, String, String)
 }
 
 extension ImageOperationsTarget: BaseTargetType {
@@ -23,14 +23,14 @@ extension ImageOperationsTarget: BaseTargetType {
         case .getDirectoryList(let value):
             return ImageOperationsAPI.directoryList(value).apiDesc
             
-        case .getContentList(let storage, let directory, _, _, _):
-            return ImageOperationsAPI.contentList(storage, directory).apiDesc
+//        case .getContentList(let storage, let directory, _, _, _):
+//            return ImageOperationsAPI.contentList(storage, directory).apiDesc
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getStorageList, .getDirectoryList, .getContentList:
+        case .getStorageList, .getDirectoryList:
                 .get
         }
     }
@@ -40,13 +40,13 @@ extension ImageOperationsTarget: BaseTargetType {
         case .getStorageList, .getDirectoryList:
             return .requestPlain
             
-        case .getContentList(_, _, let type, let kind, let order):
-            let parameters: [String : Any] = [
-                "type" : type,
-                "kind" : kind,
-                "order" : order
-            ]
-            return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
+//        case .getContentList(_, _, let type, let kind, let order):
+//            let parameters: [String : Any] = [
+//                "type" : type,
+//                "kind" : kind,
+//                "order" : order
+//            ]
+//            return .requestParameters(parameters: parameters, encoding: URLEncoding.queryString)
         }
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Core/Network/DigestAuth/NetworkManager.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/DigestAuth/NetworkManager.swift
@@ -129,15 +129,6 @@ class NetworkManager {
         }
     }
     
-    /// Authorization 헤더 생성 (외부에서 사용 가능)
-    func getAuthorizationHeader(method: String, url: String, body: Data?) -> String? {
-        return authManager?.getAuthorizationHeader(
-            method: method,
-            url: url,
-            body: body
-        )
-    }
-    
     /// 인증 리셋
     func resetAuthentication() {
         authManager?.reset()
@@ -146,18 +137,6 @@ class NetworkManager {
     /// Digest Auth 헤더 가져오기 (Event Monitoring 등 스트리밍용)
     func getAuthorizationHeader(method: String, url: String, body: Data? = nil) -> String? {
         return authManager?.getAuthorizationHeader(method: method, url: url, body: body)
-    }
-    
-    func getAuthorizationHeader(
-        method: String,
-        url: String,
-        body: Data? = nil
-    ) -> String? {
-        return authManager?.getAuthorizationHeader(
-            method: method,
-            url: url,
-            body: body
-        )
     }
     
     // MARK: - Private Methods

--- a/HonestHouse/HonestHouse/Sources/Core/Network/DigestAuth/NetworkManager.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/DigestAuth/NetworkManager.swift
@@ -129,6 +129,15 @@ class NetworkManager {
         }
     }
     
+    /// Authorization 헤더 생성 (외부에서 사용 가능)
+    func getAuthorizationHeader(method: String, url: String, body: Data?) -> String? {
+        return authManager?.getAuthorizationHeader(
+            method: method,
+            url: url,
+            body: body
+        )
+    }
+    
     /// 인증 리셋
     func resetAuthentication() {
         authManager?.reset()

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Shared/ArchiveErrorHandleable.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Shared/ArchiveErrorHandleable.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@MainActor
 protocol ArchiveErrorHandleable: AnyObject {
     associatedtype Success: Equatable
     associatedtype Failure: Error & Equatable

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosView.swift
@@ -20,7 +20,7 @@ struct GroupedPhotosView: View {
     }
     
     var body: some View {
-        NavigationStack {
+        ZStack {
             switch vm.groupingState {
             case .idle, .loading:
                 ProgressView()
@@ -37,7 +37,6 @@ struct GroupedPhotosView: View {
             }
         }
         .task {
-//            vm.configure(container: container)
             vm.startGrouping()
         }
         .onChange(of: vm.groupingState) { _, newState in

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionView.swift
@@ -46,7 +46,9 @@ struct PhotoSelectionView: View {
             .navigationTitle("카메라 이름")
             .navigationBarTitleDisplayMode(.large)
             .task {
-                await vm.fetchFirstPageImage()
+                if vm.entireContentUrls.isEmpty {
+                    await vm.fetchAllImages()
+                }
             }
             .onChange(of: vm.state) { _, newState in
                 if case .failure(let error) = newState {
@@ -70,16 +72,7 @@ struct PhotoSelectionView: View {
                         isSelected: vm.selectedPhotos.contains(where: { $0.url == url }),
                         onTapSelectionGridCell: { vm.toggleGridCell(for: photo) }
                     )
-                    .id(url)  // URL을 id로 사용
-                }
-                
-                if vm.hasMore {
-                    ProgressView()
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 12)
-                        .task {
-                            await vm.loadCurrentPageSafely()
-                        }
+                    .id(url)
                 }
             }
             .padding(.horizontal, 2)

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.7. ImageOperationsService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.7. ImageOperationsService.swift
@@ -8,6 +8,7 @@
 import Combine
 import CombineMoya
 import Moya
+import Foundation
 
 protocol ImageOperationsServiceType {
     /// storageList 조회
@@ -17,10 +18,12 @@ protocol ImageOperationsServiceType {
     func getDirectoryList(storage: String) async throws -> ImageOperations.DirectoryListResponse
     
     /// contentList(이미지 리스트) 조회
-    func getContentList(storage: String, directory: String, type: String, kind: String, page: Int) async throws -> ImageOperations.ContentListResponse
+    func getContentList(storage: String, directory: String, type: String, order: String, onProgress: @escaping ([String]) -> Void) async throws -> ImageOperations.ContentListResponse
 }
 
 final class ImageOperationsService: BaseService, ImageOperationsServiceType {
+    
+    private let streamDownloadService = StreamDownloadService.shared
     
     // MARK: - GET list of storage URLs
     func getStorageList() async throws -> ImageOperations.StorageListResponse {
@@ -37,10 +40,87 @@ final class ImageOperationsService: BaseService, ImageOperationsServiceType {
     }
     
     // MARK: - GET list of Content URLs
-    func getContentList(storage: String, directory: String, type: String, kind: String, page: Int) async throws -> ImageOperations.ContentListResponse {
-        let response = try await request(ImageOperationsTarget.getContentList(storage, directory, type, kind, page), decoding: ImageOperations.ContentListResponse.self)
+    func getContentList(
+        storage: String,
+        directory: String,
+        type: String,
+        order: String,
+        onProgress: @escaping ([String]) -> Void
+    ) async throws -> ImageOperations.ContentListResponse {
         
-        return response
+        let url = try buildContentListURL(
+            storage: storage,
+            directory: directory,
+            type: type,
+            kind: "chunked",
+            order: order
+        )
+        
+        var finalUrls: [String] = []
+        
+        // StreamDownloadService 사용
+        try await streamDownloadService.stream(
+            from: url,
+            headers: APIConstants.baseHeader,
+            decoding: ImageOperations.ContentListResponse.self,
+            onProgress: { responses in
+                let allUrls = responses.flatMap { $0.url ?? [] }
+                onProgress(allUrls)
+            },
+            onComplete: { responses in
+                finalUrls = responses.flatMap { $0.url ?? [] }
+            }
+        )
+        
+        return ImageOperations.ContentListResponse(url: finalUrls)
+    }
+    
+    // MARK: - Private Methods
+    
+    private func getContentListChunked(
+        storage: String,
+        directory: String,
+        type: String,
+        order: String
+    ) async throws -> ImageOperations.ContentListResponse {
+        
+        let url = try buildContentListURL(
+            storage: storage,
+            directory: directory,
+            type: type,
+            kind: "chunked",
+            order: order
+        )
+        
+        var finalUrls: [String] = []
+        
+        try await streamDownloadService.stream(
+            from: url,
+            headers: APIConstants.baseHeader,
+            decoding: ImageOperations.ContentListResponse.self,
+            onProgress: { _ in },
+            onComplete: { responses in
+                finalUrls = responses.flatMap { $0.url ?? [] }
+            }
+        )
+        
+        return ImageOperations.ContentListResponse(url: finalUrls)
+    }
+    
+    private func buildContentListURL(
+        storage: String,
+        directory: String,
+        type: String,
+        kind: String,
+        order: String
+    ) throws -> URL {
+        let urlString = "\(BaseAPI.base.apiDesc)ver100/contents/\(storage)/\(directory)?type=\(type)&kind=\(kind)&order=\(order)"
+        
+        guard let url = URL(string: urlString) else {
+            throw CCAPIError.invalidURL
+        }
+        
+        return url
     }
 }
 
@@ -55,7 +135,7 @@ class StubImageOperationsService: ImageOperationsServiceType {
         return .stub1
     }
     
-    func getContentList(storage: String, directory: String, type: String, kind: String, page: Int) async throws -> ImageOperations.ContentListResponse {
+    func getContentList(storage: String, directory: String, type: String, order: String, onProgress: @escaping ([String]) -> Void) async throws -> ImageOperations.ContentListResponse {
         return .stub1
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.7. ImageOperationsService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.7. ImageOperationsService.swift
@@ -84,36 +84,6 @@ final class ImageOperationsService: BaseService, ImageOperationsServiceType {
         return ImageOperations.ContentListResponse(url: allUrls)
     }
     
-    private func getContentListChunked(
-        storage: String,
-        directory: String,
-        type: String,
-        order: String
-    ) async throws -> ImageOperations.ContentListResponse {
-        
-        let url = try buildContentListURL(
-            storage: storage,
-            directory: directory,
-            type: type,
-            kind: "chunked",
-            order: order
-        )
-        
-        var finalUrls: [String] = []
-        
-        try await streamDownloadService.stream(
-            from: url,
-            headers: APIConstants.baseHeader,
-            decoding: ImageOperations.ContentListResponse.self,
-            onProgress: { _ in },
-            onComplete: { responses in
-                finalUrls = responses.flatMap { $0.url ?? [] }
-            }
-        )
-        
-        return ImageOperations.ContentListResponse(url: finalUrls)
-    }
-    
     private func buildContentListURL(
         storage: String,
         directory: String,

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.7. ImageOperationsService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.7. ImageOperationsService.swift
@@ -66,7 +66,9 @@ final class ImageOperationsService: BaseService, ImageOperationsServiceType {
             onProgress: { responses in
                 let mergedResponse = Self.mergeResponses(responses)
                 
-                onProgress(mergedResponse)
+                DispatchQueue.main.async {
+                    onProgress(mergedResponse)
+                }
             },
             onComplete: { responses in
                 allResponses = responses

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.7. ImageOperationsService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.7. ImageOperationsService.swift
@@ -65,9 +65,8 @@ final class ImageOperationsService: BaseService, ImageOperationsServiceType {
             decoding: ImageOperations.ContentListResponse.self,
             onProgress: { responses in
                 let mergedResponse = Self.mergeResponses(responses)
-                onProgress(mergedResponse)
                 
-                allResponses = responses
+                onProgress(mergedResponse)
             },
             onComplete: { responses in
                 allResponses = responses

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/BaseStreamService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/BaseStreamService.swift
@@ -1,0 +1,82 @@
+//
+//  BaseStreamService.swift
+//  HonestHouse
+//
+//  Created by 이현주 on 11/1/25.
+//
+
+import Foundation
+
+/// 스트리밍 서비스의 공통 기능을 제공하는 Base 클래스
+class BaseStreamService {
+    
+    // MARK: - Properties
+    
+    private let networkManager: NetworkManager = NetworkManager.shared
+    
+    // MARK: - Protected Methods (서브클래스에서 사용)
+    
+    /// URLSession 설정 생성
+    func createSessionConfiguration() -> URLSessionConfiguration {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = .infinity
+        config.timeoutIntervalForResource = .infinity
+        config.waitsForConnectivity = true
+        return config
+    }
+    
+    /// 인증 헤더 가져오기
+    func getAuthorizationHeader(for url: URL, method: String) async -> String? {
+        do {
+            try await networkManager.initializeAuthentication()
+        } catch {
+            print("⚠️ Auth initialization failed: \(error)")
+            return nil
+        }
+        
+        return networkManager.getAuthorizationHeader(
+            method: method,
+            url: url.absoluteString,
+            body: nil
+        )
+    }
+    
+    /// URLRequest 생성 (인증 포함)
+    func createAuthenticatedRequest(
+        url: URL,
+        method: String,
+        headers: [String: String]? = nil
+    ) async -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        
+        // 인증 헤더
+        if let authHeader = await getAuthorizationHeader(for: url, method: method) {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+            print("🔑 Authorization header added")
+        } else {
+            print("⚠️ No Authorization header")
+        }
+        
+        // 추가 헤더
+        headers?.forEach { key, value in
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        
+        return request
+    }
+    
+    /// SSL Challenge 처리
+    func handleSSLChallenge(
+        _ challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+           let serverTrust = challenge.protectionSpace.serverTrust {
+            let credential = URLCredential(trust: serverTrust)
+            completionHandler(.useCredential, credential)
+        } else {
+            completionHandler(.performDefaultHandling, nil)
+        }
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/StreamDownload/StreamDownloadDelegate.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/StreamDownload/StreamDownloadDelegate.swift
@@ -1,0 +1,208 @@
+//
+//  StreamDownloadDelegate.swift
+//  HonestHouse
+//
+//  Created by 이현주 on 10/31/25.
+//
+
+import Foundation
+
+/// 점진적 다운로드의 JSON 파싱 델리게이트
+/// - URLSessionDataDelegate 구현
+/// - 실시간으로 완성된 JSON 객체를 파싱하여 콜백
+final class StreamDownloadDelegate<T: Decodable>: NSObject, URLSessionDataDelegate {
+    
+    // MARK: - Properties
+    
+    private let onProgress: ([T]) -> Void
+    private let onComplete: ([T]) -> Void
+    
+    var completion: ((Result<Void, Error>) -> Void)?
+    private var hasCompleted = false
+    
+    // MARK: - Parsing State
+    
+    private var rawDataBuffer = Data()
+    private var jsonTextBuffer = ""
+    private var braceDepth = 0
+    private var parsedObjects: [T] = []
+    
+    private let decoder = JSONDecoder()
+    
+    // MARK: - Initialization
+    
+    init(
+        decodingType: T.Type,  // 파라미터로만 받고 저장 안 함
+        onProgress: @escaping ([T]) -> Void,
+        onComplete: @escaping ([T]) -> Void
+    ) {
+        self.onProgress = onProgress
+        self.onComplete = onComplete
+    }
+    
+    // MARK: - URLSessionDataDelegate
+    
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive data: Data
+    ) {
+        rawDataBuffer.append(data)
+        
+        print("📥 Chunk received: \(data.count) bytes (Buffer: \(rawDataBuffer.count) bytes)")
+        
+        guard let newText = String(data: data, encoding: .utf8) else {
+            print("⚠️ Failed to decode chunk as UTF-8")
+            return
+        }
+        
+        jsonTextBuffer.append(newText)
+        
+        let newlyParsed = parseCompletedJSONObjects(from: newText)
+        
+        if !newlyParsed.isEmpty {
+            parsedObjects.append(contentsOf: newlyParsed)
+            print("✅ Parsed \(newlyParsed.count) objects (Total: \(parsedObjects.count))")
+            onProgress(parsedObjects)
+        }
+    }
+    
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            completionHandler(.allow)
+            return
+        }
+        
+        print("📡 Response status: \(httpResponse.statusCode)")
+        
+        if let error = validateResponseStatus(httpResponse.statusCode) {
+            completionHandler(.cancel)
+            return
+        }
+        
+        completionHandler(.allow)
+    }
+    
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        // ✅ 이미 완료되었으면 무시
+        guard !hasCompleted else {
+            print("⚠️ Already completed, ignoring")
+            return
+        }
+        
+        hasCompleted = true
+        
+        if let error = error {
+            // Cancellation은 정상적인 종료 (401 등)
+            if (error as NSError).code == NSURLErrorCancelled {
+                print("⚠️ Task cancelled (likely due to error response)")
+                // 상태 코드 에러로 처리
+                if let httpResponse = task.response as? HTTPURLResponse,
+                   let statusError = validateResponseStatus(httpResponse.statusCode) {
+                    completion?(.failure(statusError))
+                } else {
+                    completion?(.failure(error))
+                }
+            } else {
+                print("❌ Stream error: \(error)")
+                completion?(.failure(error))
+            }
+        } else {
+            print("✅ Stream completed: \(parsedObjects.count) objects")
+            onComplete(parsedObjects)
+            completion?(.success(()))
+        }
+    }
+    
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        handleSSLChallenge(challenge, completionHandler: completionHandler)
+    }
+    
+    // MARK: - Private Methods - Parsing
+    
+    private func parseCompletedJSONObjects(from newText: String) -> [T] {
+        var completed: [T] = []
+        var currentObjectBuffer = ""
+        
+        for char in newText {
+            if char == "{" {
+                if braceDepth == 0 {
+                    currentObjectBuffer = ""
+                }
+                braceDepth += 1
+            }
+            
+            currentObjectBuffer.append(char)
+            
+            if char == "}" {
+                braceDepth -= 1
+                
+                if braceDepth == 0 {
+                    if let parsed = decodeJSONObject(from: currentObjectBuffer) {
+                        completed.append(parsed)
+                    }
+                    currentObjectBuffer = ""
+                }
+            }
+        }
+        
+        return completed
+    }
+    
+    private func decodeJSONObject(from jsonString: String) -> T? {
+        let trimmed = jsonString.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        guard !trimmed.isEmpty,
+              let jsonData = trimmed.data(using: .utf8) else {
+            return nil
+        }
+        
+        do {
+            return try decoder.decode(T.self, from: jsonData)
+        } catch {
+            print("⚠️ JSON decode error: \(error)")
+            return nil
+        }
+    }
+    
+    // MARK: - Private Methods - Validation
+    
+    private func validateResponseStatus(_ statusCode: Int) -> Error? {
+        switch statusCode {
+        case 200...299:
+            return nil
+        case 401:
+            print("⚠️ 401 Unauthorized")
+            return CCAPIError.authenticationFailed(401)
+        default:
+            print("⚠️ Unexpected status: \(statusCode)")
+            return CCAPIError.unexpectedStatusCode(statusCode)
+        }
+    }
+    
+    private func handleSSLChallenge(
+        _ challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+           let serverTrust = challenge.protectionSpace.serverTrust {
+            let credential = URLCredential(trust: serverTrust)
+            completionHandler(.useCredential, credential)
+        } else {
+            completionHandler(.performDefaultHandling, nil)
+        }
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/StreamDownload/StreamDownloadService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/StreamDownload/StreamDownloadService.swift
@@ -1,0 +1,143 @@
+//
+//  StreamDownloadService.swift
+//  HonestHouse
+//
+//  Created by 이현주 on 10/31/25.
+//
+
+import Foundation
+
+/// Chunked Transfer Encoding 응답을 스트리밍으로 처리하는 서비스
+/// - 유한한 스트림 (서버가 모든 데이터 전송 후 연결 종료)
+/// - JSON 객체들을 실시간으로 파싱
+class StreamDownloadService {
+    
+    static let shared = StreamDownloadService()
+    
+    // MARK: - Properties
+    private let networkManager: NetworkManager
+    
+    // MARK: - Configuration
+    private enum Configuration {
+        static let requestTimeout: TimeInterval = 300
+        static let resourceTimeout: TimeInterval = 600
+    }
+    
+    // MARK: - Initialization
+    private init(networkManager: NetworkManager = .shared) {
+        self.networkManager = networkManager
+    }
+    
+    // MARK: - Public Methods
+    
+    /// Chunked 응답을 스트리밍하며 점진적으로 파싱
+    /// - Parameters:
+    ///   - url: 요청 URL
+    ///   - headers: 추가 헤더
+    ///   - type: 디코딩할 타입
+    ///   - onProgress: 청크를 받을 때마다 호출 (누적된 전체 데이터)
+    ///   - onComplete: 완료 시 호출 (최종 전체 데이터)
+    func stream<T: Decodable>(
+        from url: URL,
+        headers: [String: String]? = nil,
+        decoding type: T.Type,
+        onProgress: @escaping ([T]) -> Void,
+        onComplete: @escaping ([T]) -> Void
+    ) async throws {
+        
+        let request = try await buildRequest(for: url, headers: headers)
+        let delegate = createDelegate(
+            decodingType: type,
+            onProgress: onProgress,
+            onComplete: onComplete
+        )
+        
+        try await executeStreamRequest(request: request, delegate: delegate)
+    }
+    
+    // MARK: - Protected Methods (서브클래스에서 오버라이드 가능)
+    
+    /// 요청 헤더 커스터마이징 (서브클래스에서 오버라이드 가능)
+    func customizeRequest(_ request: inout URLRequest) {
+        // 기본 구현: 아무것도 하지 않음
+        // 서브클래스에서 필요시 오버라이드
+    }
+    
+    // MARK: - Private Methods - Request Building
+    
+    private func buildRequest(for url: URL, headers: [String: String]?) async throws -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = Configuration.requestTimeout
+        
+        // Digest 인증
+        if let authHeader = await getAuthorizationHeader(for: url) {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        }
+        
+        // 추가 헤더
+        headers?.forEach { key, value in
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        
+        // 서브클래스 커스터마이징 적용
+        customizeRequest(&request)
+        
+        return request
+    }
+    
+    private func getAuthorizationHeader(for url: URL) async -> String? {
+        do {
+            try await networkManager.initializeAuthentication()
+            return networkManager.getAuthorizationHeader(
+                method: "GET",
+                url: url.absoluteString,
+                body: nil
+            )
+        } catch {
+            print("⚠️ Auth initialization failed: \(error)")
+            return nil
+        }
+    }
+    
+    // MARK: - Private Methods - Delegate
+    
+    private func createDelegate<T: Decodable>(
+        decodingType: T.Type,
+        onProgress: @escaping ([T]) -> Void,
+        onComplete: @escaping ([T]) -> Void
+    ) -> StreamDownloadDelegate<T> {
+        StreamDownloadDelegate(
+            decodingType: decodingType,
+            onProgress: onProgress,
+            onComplete: onComplete
+        )
+    }
+    
+    // MARK: - Private Methods - Execution
+    
+    private func executeStreamRequest<T>(
+        request: URLRequest,
+        delegate: StreamDownloadDelegate<T>
+    ) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            delegate.completion = { result in
+                continuation.resume(with: result)
+            }
+            
+            // URLSession 생성 (delegate 포함)
+            let configuration = URLSessionConfiguration.default
+            configuration.timeoutIntervalForRequest = Configuration.requestTimeout
+            configuration.timeoutIntervalForResource = Configuration.resourceTimeout
+            
+            let session = URLSession(
+                configuration: configuration,
+                delegate: delegate,
+                delegateQueue: nil
+            )
+            
+            let task = session.dataTask(with: request)
+            task.resume()
+        }
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/StreamDownload/StreamDownloadService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/StreamDownload/StreamDownloadService.swift
@@ -10,23 +10,9 @@ import Foundation
 /// Chunked Transfer Encoding 응답을 스트리밍으로 처리하는 서비스
 /// - 유한한 스트림 (서버가 모든 데이터 전송 후 연결 종료)
 /// - JSON 객체들을 실시간으로 파싱
-class StreamDownloadService {
+class StreamDownloadService: BaseStreamService {
     
     static let shared = StreamDownloadService()
-    
-    // MARK: - Properties
-    private let networkManager: NetworkManager
-    
-    // MARK: - Configuration
-    private enum Configuration {
-        static let requestTimeout: TimeInterval = 300
-        static let resourceTimeout: TimeInterval = 600
-    }
-    
-    // MARK: - Initialization
-    private init(networkManager: NetworkManager = .shared) {
-        self.networkManager = networkManager
-    }
     
     // MARK: - Public Methods
     
@@ -45,99 +31,37 @@ class StreamDownloadService {
         onComplete: @escaping ([T]) -> Void
     ) async throws {
         
-        let request = try await buildRequest(for: url, headers: headers)
-        let delegate = createDelegate(
-            decodingType: type,
-            onProgress: onProgress,
-            onComplete: onComplete
+        let request = await createAuthenticatedRequest(
+            url: url,
+            method: "GET",
+            headers: headers
         )
         
-        try await executeStreamRequest(request: request, delegate: delegate)
-    }
-    
-    // MARK: - Protected Methods (서브클래스에서 오버라이드 가능)
-    
-    /// 요청 헤더 커스터마이징 (서브클래스에서 오버라이드 가능)
-    func customizeRequest(_ request: inout URLRequest) {
-        // 기본 구현: 아무것도 하지 않음
-        // 서브클래스에서 필요시 오버라이드
-    }
-    
-    // MARK: - Private Methods - Request Building
-    
-    private func buildRequest(for url: URL, headers: [String: String]?) async throws -> URLRequest {
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.timeoutInterval = Configuration.requestTimeout
+        let config = createSessionConfiguration()
         
-        // Digest 인증
-        if let authHeader = await getAuthorizationHeader(for: url) {
-            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
-        }
-        
-        // 추가 헤더
-        headers?.forEach { key, value in
-            request.setValue(value, forHTTPHeaderField: key)
-        }
-        
-        // 서브클래스 커스터마이징 적용
-        customizeRequest(&request)
-        
-        return request
-    }
-    
-    private func getAuthorizationHeader(for url: URL) async -> String? {
-        do {
-            try await networkManager.initializeAuthentication()
-            return networkManager.getAuthorizationHeader(
-                method: "GET",
-                url: url.absoluteString,
-                body: nil
-            )
-        } catch {
-            print("⚠️ Auth initialization failed: \(error)")
-            return nil
-        }
-    }
-    
-    // MARK: - Private Methods - Delegate
-    
-    private func createDelegate<T: Decodable>(
-        decodingType: T.Type,
-        onProgress: @escaping ([T]) -> Void,
-        onComplete: @escaping ([T]) -> Void
-    ) -> StreamDownloadDelegate<T> {
-        StreamDownloadDelegate(
-            decodingType: decodingType,
+        let delegate = StreamDownloadDelegate(
+            decodingType: T.self,
             onProgress: onProgress,
-            onComplete: onComplete
+            onComplete: onComplete,
+            sslHandler: handleSSLChallenge
         )
-    }
-    
-    // MARK: - Private Methods - Execution
-    
-    private func executeStreamRequest<T>(
-        request: URLRequest,
-        delegate: StreamDownloadDelegate<T>
-    ) async throws {
+        
+        let session = URLSession(
+            configuration: config,
+            delegate: delegate,
+            delegateQueue: nil
+        )
+        
+        // Continuation으로 async/await 지원
         try await withCheckedThrowingContinuation { continuation in
             delegate.completion = { result in
                 continuation.resume(with: result)
             }
             
-            // URLSession 생성 (delegate 포함)
-            let configuration = URLSessionConfiguration.default
-            configuration.timeoutIntervalForRequest = Configuration.requestTimeout
-            configuration.timeoutIntervalForResource = Configuration.resourceTimeout
-            
-            let session = URLSession(
-                configuration: configuration,
-                delegate: delegate,
-                delegateQueue: nil
-            )
-            
             let task = session.dataTask(with: request)
             task.resume()
         }
+        
+        session.invalidateAndCancel()
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Service/LiveViewService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/LiveViewService.swift
@@ -19,7 +19,7 @@ class LiveViewService: StreamService {
         return ChunkedStreamParser(streamType: .scroll)
     }()
 
-    private init() {
+    private override init() {
         super.init()
     }
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #37

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- JPEG 이미지를 찍은 최신순으로 정렬하기 위해 ImageOperationsService 내의 getContentList메서드 변경: 
   - kind = chunked로 바뀌면서 response를 json형태가 아닌 chunk형태로 받게 됨.
   - 필요한 메서드 추가
- 이에 따른 PhotoSelectionView와 PhotoSelectionViewModel 수정
- chunk 데이터 처리를 위해 urlSession 사용 정의할 StreamDownloadService 및 StreamDownloadServiceDelegate 구현

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/3bf8d777-1a0e-4dba-9b47-ca9538b86fa2

https://github.com/user-attachments/assets/d366e60e-083d-4eef-aeed-360937aadbb0

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] 정상적인 api 통신 확인
- [x] chunk data 잘 오는지 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

## 모든 StreamService의 공통 메서드만 정의한 BaseStreamService 구현
### 1. 구현 배경
문제 상황:
- Content List 조회 시 4,887개의 이미지 URL을 한 번에 받아오면서 모든 chunk가 도착할 때까지 화면이 로딩중에서 넘어가지 않음.
- 서버는 chunked Transfer-Encoding을 지원하여 점진적 전송이 가능한 상황


해결 방향:
- Chunked 스트리밍을 활용한 점진적 로딩 구현 필요
- 기존 StreamService를 활용할지, 새로운 서비스를 만들지 고민

### 2. StreamService를 재사용할 수 없는 이유
- 초기 접근: StreamService 재사용 시도
- StreamService를 상속받아 Content List를 구현하려고 했으나, 근본적인 설계 차이로 인해 불가능함

1. getContentList는 동적 파라미터 처리. 이전에 두개의 api를 더 불러서 파라미터에 채워야 할 내용을 구해야 함.
```
  override var endpoint: String {
     return "ver100/contents/\(storage)/\(directory)"  //  동적 파라미터 처리 어려움
  }
```
2. 비동기 패러다임의 근본적 차이
- StreamService: 콜백 기반 (Callback-based)
```
func startStreaming(
    onData: @escaping (Data) -> Void,
    onError: @escaping (Error) -> Void
) async -> Bool {
    // 시작만 하고 즉시 반환
    streamingTask?.resume()
    return true
}

// 사용
await service.startStreaming(
    onData: { data in
        // 나중에 데이터가 올 때마다 호출
    },
    onError: { error in
        // 나중에 에러가 발생하면 호출
    }
)
// 여기서 함수는 끝났지만 스트리밍은 계속 진행 중
```

- 콜백인 이유
   - 함수가 즉시 반환되지만 작업은 계속 진행 중
   - 데이터가 언제 올지, 에러가 언제 발생할지 모름
   - 비결정적 시간에 발생하는 이벤트를 처리해야 함


- StreamDownloadService: async/await 기반
```
func stream<T: Decodable>(
    from url: URL,
    decoding: T.Type,
    onProgress: @escaping ([T]) -> Void
) async throws {
    // 작업이 완료될 때까지 대기
    try await withCheckedThrowingContinuation { continuation in
        // ...
    }
    // 여기 도달하면 작업 완료
}

// 사용
do {
    try await service.stream(...)
    // 여기 오면 100% 완료된 상태
} catch {
    // 에러 처리 (한 번만)
}
```

- async/await인 이유
   - 함수가 완료될 때까지 **대기**
   - 작업의 **시작과 끝이 명확**함
   - **결정적 시간**에 완료되는 작업

---

3. 생명주기의 차이 (다른 패러다임 때문에)

**StreamService: 무한 생명주기**
```
// 사용자가 제어
await service.startStreaming(...)  // 시작
// ... 데이터가 무한히 들어오는 중 ...
// ... 사용자가 화면을 닫을 때까지 계속 ...
await service.stopStreaming()      // 명시적 종료 + DELETE 요청
```
- 함수가 **먼저 반환**되고 이벤트는 **나중에** 발생
- 언제 끝날지 모름 (사용자가 결정)
- **상태 관리 필수** (`isStreaming`)

---

**StreamDownloadService: 유한 생명주기**
```
// 자동 완료
try await service.stream(...)  // 시작 → 완료까지 자동
// 여기 도달 시 이미 완료됨


사용자 행동          시스템 상태
─────────────────────────────────────────
stream() 호출
    ↓
서버 연결
    ↓               ├─ 청크 1 수신 
    ↓               ├─ 청크 2 수신 
    ↓               ├─ 청크 3 수신 
    ↓               ├─ ...
    ↓               └─ 청크 49 수신
    ↓
서버 완료
    ↓
함수 반환
```
- 명확한 시작과 끝이 있음
- 함수가 끝나면 작업도 끝남
- 상태 관리 불필요

### 3. 각각 다른 Service 구현 후, 상속받을 BaseStreamService 구현
- 각각 구현하려니, 근본적인 문제는 다르지만 받아오는 응답이 "chunk"라는 공통점 때문에 urlSession과 delegate를 쓰는 방식은 동일했음
- URLSession 설정 생성, 인증 헤더 가져오기(networkManager 사용), URLRequest 생성(인증 포함), SSL Challenge 처리 등 중복되는 메서드가 생김 -> **분리 및 재사용**
- urlSession, streamingTask 변수 공통으로 빼지 않은 이유?
   - StreamService는 나중에 취소하기 위해 저장 필요(stopStreaming()), StreamDownloadService는 함수가 끝나면 자동 정리되므로 저장 불필요
- 효과: StreamService, StreamDownloadService는 각각 책임 분명해짐


이렇게 구현해봤는데, 피드백 환영입니다.

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
- BaseStreamService
- Caching will comeback soon...🔪


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **개선사항**
  * 콘텐츠 로딩 방식 개선으로 더욱 빠르고 매끄러운 성능 제공
  * 이미지 선택 및 그룹화 기능의 안정성 향상

* **버그 수정**
  * 보관함 뷰 레이아웃 및 이미지 로딩 로직 최적화
  * 선택된 사진 관리 시스템 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->