### PR TITLE
Feat: #65 카메라 연결 체크 로직 구현

### DIFF
--- a/HonestHouse/HonestHouse/Sources/Core/Managers/CameraConnectionManager.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Managers/CameraConnectionManager.swift
@@ -54,6 +54,18 @@ final class CameraConnectionManager: ObservableObject {
         connectionState = .disconnected
     }
     
+    @discardableResult
+    func checkConnectionStatus() async -> Bool {
+        do {
+            _ = try await getCameraInfo(with: .ver100)
+            self.connectionState = .connected
+            return true
+        } catch {
+            self.connectionState = .disconnected
+            return false
+        }
+    }
+    
     func getCameraInfo(with: VersionType) async throws -> CameraInformation.CameraFixedInformationResponse {
         let response = try await networkManager.request(CameraInformationTarget.getCameraFixedInformation)
         

--- a/HonestHouse/HonestHouse/Sources/Core/Managers/CameraConnectionManager.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Managers/CameraConnectionManager.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 @MainActor
-final class CameraConnectionManager: ObservableObject {
+final class CameraConnectionManager: BaseService, ObservableObject {
     
     @Published var productName: String = ""
     @Published var connectionState: ConnectionState = .disconnected
@@ -37,7 +37,7 @@ final class CameraConnectionManager: ObservableObject {
                 self.connectionState = .connected
                 print("✅ 카메라 연결 성공")
                 
-                let cameraInfo = try await getCameraInfo(with: .ver100)
+                let cameraInfo = try await getCameraInfo()
                 
                 if let productName = cameraInfo.productName {
                     self.productName = productName
@@ -57,7 +57,7 @@ final class CameraConnectionManager: ObservableObject {
     @discardableResult
     func checkConnectionStatus() async -> Bool {
         do {
-            _ = try await getCameraInfo(with: .ver100)
+            _ = try await getCameraInfo()
             self.connectionState = .connected
             return true
         } catch {
@@ -66,14 +66,9 @@ final class CameraConnectionManager: ObservableObject {
         }
     }
     
-    func getCameraInfo(with: VersionType) async throws -> CameraInformation.CameraFixedInformationResponse {
-        let response = try await networkManager.request(CameraInformationTarget.getCameraFixedInformation)
+    func getCameraInfo() async throws -> CameraInformation.CameraFixedInformationResponse {
+        let response = try await request(CameraInformationTarget.getCameraFixedInformation, decoding: CameraInformation.CameraFixedInformationResponse.self)
         
-        do {
-            let decodedResponse = try jsonDecoder.decode(CameraInformation.CameraFixedInformationResponse.self, from: response.data)
-            return decodedResponse
-        } catch {
-            throw error
-        }
+        return response
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Core/Managers/CameraConnectionManager.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Managers/CameraConnectionManager.swift
@@ -9,10 +9,13 @@ import SwiftUI
 @MainActor
 final class CameraConnectionManager: ObservableObject {
     
+    @Published var productName: String = ""
     @Published var connectionState: ConnectionState = .disconnected
     @Published var showConnectionSheet = false
     
     private let networkManager: NetworkManager
+    private let jsonDecoder = JSONDecoder()
+    
     
     init(networkManager: NetworkManager = .shared) {
         self.networkManager = networkManager
@@ -33,6 +36,12 @@ final class CameraConnectionManager: ObservableObject {
                 try await networkManager.initializeAuthentication()
                 self.connectionState = .connected
                 print("✅ 카메라 연결 성공")
+                
+                let cameraInfo = try await getCameraInfo(with: .ver100)
+                
+                if let productName = cameraInfo.productName {
+                    self.productName = productName
+                }
             } catch {
                 let connectionError = ConnectionError.from(error)
                 self.connectionState = .failed(connectionError)
@@ -43,5 +52,16 @@ final class CameraConnectionManager: ObservableObject {
     
     func disconnectCamera() {
         connectionState = .disconnected
+    }
+    
+    func getCameraInfo(with: VersionType) async throws -> CameraInformation.CameraFixedInformationResponse {
+        let response = try await networkManager.request(CameraInformationTarget.getCameraFixedInformation)
+        
+        do {
+            let decodedResponse = try jsonDecoder.decode(CameraInformation.CameraFixedInformationResponse.self, from: response.data)
+            return decodedResponse
+        } catch {
+            throw error
+        }
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Core/Model/4.3. Camera Information/1. CameraFixedInformation.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Model/4.3. Camera Information/1. CameraFixedInformation.swift
@@ -1,0 +1,17 @@
+//
+//  1. CameraFixedInformation.swift
+//  HonestHouse
+//
+//  Created by Rama on 11/4/25.
+//
+
+import Foundation
+
+struct CameraFixedInformation {
+    let manufacturer: String?
+    let productName: String?
+    let guid: String?
+    let serialNumber: String?
+    let macAddress: String?
+    let firmwareVersion: String?
+}

--- a/HonestHouse/HonestHouse/Sources/Core/Model/4.3. Camera Information/1. CameraFixedInformation.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Model/4.3. Camera Information/1. CameraFixedInformation.swift
@@ -1,5 +1,5 @@
 //
-//  1. CameraFixedInformation.swift
+//  CameraFixedInformation.swift
 //  HonestHouse
 //
 //  Created by Rama on 11/4/25.

--- a/HonestHouse/HonestHouse/Sources/Core/Model/Photo.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Model/Photo.swift
@@ -58,5 +58,9 @@ extension Photo {
             Photo(url: "\(baseURL)/photo\(index).JPG")
         }
     }
+    
+    static func mockPhoto() -> Photo {
+        return Photo(url: "https://raw.githubusercontent.com/Rama-Moon/MockImage/main/photo1.JPG")
+    }
 }
 

--- a/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.3. Camera Information/CameraInformationAPI.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.3. Camera Information/CameraInformationAPI.swift
@@ -1,0 +1,19 @@
+//
+//  CameraInformationAPI.swift
+//  HonestHouse
+//
+//  Created by Rama on 11/4/25.
+//
+
+import Foundation
+
+enum CameraInformationAPI {
+    case cameraFixedInformation
+    
+    var apiDesc: String {
+        switch self {
+        case .cameraFixedInformation:
+            "ver100/deviceinformation"
+        }
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.3. Camera Information/CameraInformationAPI.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.3. Camera Information/CameraInformationAPI.swift
@@ -10,10 +10,14 @@ import Foundation
 enum CameraInformationAPI {
     case cameraFixedInformation
     
-    var apiDesc: String {
+    var endpoint: String {
         switch self {
         case .cameraFixedInformation:
-            "ver100/deviceinformation"
+            "deviceinformation"
         }
+    }
+    
+    func path(with version: VersionType) -> String {
+        return "\(version.description)/\(endpoint)"
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.3. Camera Information/CameraInformationTarget.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.3. Camera Information/CameraInformationTarget.swift
@@ -1,0 +1,36 @@
+//
+//  CameraInformationTarget.swift
+//  HonestHouse
+//
+//  Created by Rama on 11/4/25.
+//
+
+import Foundation
+import Moya
+
+enum CameraInformationTarget {
+    case getCameraFixedInformation
+}
+
+extension CameraInformationTarget: BaseTargetType {
+    var path: String {
+        switch self {
+        case .getCameraFixedInformation:
+            return CameraInformationAPI.cameraFixedInformation.apiDesc
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .getCameraFixedInformation:
+                .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .getCameraFixedInformation:
+            return .requestPlain
+        }
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.3. Camera Information/CameraInformationTarget.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.3. Camera Information/CameraInformationTarget.swift
@@ -16,7 +16,7 @@ extension CameraInformationTarget: BaseTargetType {
     var path: String {
         switch self {
         case .getCameraFixedInformation:
-            return CameraInformationAPI.cameraFixedInformation.apiDesc
+            return CameraInformationAPI.cameraFixedInformation.path(with: .ver100)
         }
     }
     

--- a/HonestHouse/HonestHouse/Sources/Core/Network/DTO/API+Namespace.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/DTO/API+Namespace.swift
@@ -11,3 +11,4 @@ enum ImageOperations { }    /// 4.7. Image Operations
 enum ShootingControl { }    /// 4.8. Shooting Control
 enum ShootingSettings { }   /// 4.9. Shooting Settings
 enum CameraStatus { }       /// 4.13. Camera Status
+enum CameraInformation { }

--- a/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Request/4.3. Camera Information/1. CameraFixedInformationRequest.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Request/4.3. Camera Information/1. CameraFixedInformationRequest.swift
@@ -1,5 +1,5 @@
 //
-//  1. CameraFixedInformation.swift
+//  CameraFixedInformationRequest.swift
 //  HonestHouse
 //
 //  Created by Rama on 11/4/25.

--- a/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Request/4.3. Camera Information/1. CameraFixedInformationRequest.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Request/4.3. Camera Information/1. CameraFixedInformationRequest.swift
@@ -1,0 +1,14 @@
+//
+//  1. CameraFixedInformation.swift
+//  HonestHouse
+//
+//  Created by Rama on 11/4/25.
+//
+
+import Foundation
+
+extension CameraInformation {
+    struct CameraFixedInformationRequest: BaseRequest {
+        let value: String
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.3. Camera Information/1. CameraFixedInformationResponse.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.3. Camera Information/1. CameraFixedInformationResponse.swift
@@ -16,6 +16,15 @@ extension CameraInformation {
         let serialNumber: String?
         let macAddress: String?
         let firmwareVersion: String?
+        
+        enum CodingKeys: String, CodingKey {
+            case manufacturer
+            case productName = "productname"
+            case guid
+            case serialNumber = "serialnumber"
+            case macAddress = "macaddress"
+            case firmwareVersion = "firmwareversion"
+        }
     }
 }
 

--- a/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.3. Camera Information/1. CameraFixedInformationResponse.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.3. Camera Information/1. CameraFixedInformationResponse.swift
@@ -1,5 +1,5 @@
 //
-//  1. CameraFixedInformationResponse.swift
+//  CameraFixedInformationResponse.swift
 //  HonestHouse
 //
 //  Created by Rama on 11/4/25.

--- a/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.3. Camera Information/1. CameraFixedInformationResponse.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.3. Camera Information/1. CameraFixedInformationResponse.swift
@@ -1,0 +1,46 @@
+//
+//  1. CameraFixedInformationResponse.swift
+//  HonestHouse
+//
+//  Created by Rama on 11/4/25.
+//
+
+import Foundation
+
+extension CameraInformation {
+    
+    struct CameraFixedInformationResponse: BaseResponse {
+        let manufacturer: String?
+        let productName: String?
+        let guid: String?
+        let serialNumber: String?
+        let macAddress: String?
+        let firmwareVersion: String?
+    }
+}
+
+extension CameraInformation.CameraFixedInformationResponse {
+    typealias EntityType = CameraFixedInformation
+    
+    func toEntity() -> CameraFixedInformation {
+        CameraFixedInformation(
+            manufacturer: manufacturer,
+            productName: productName,
+            guid: guid,
+            serialNumber: serialNumber,
+            macAddress: macAddress,
+            firmwareVersion: firmwareVersion
+        )
+    }
+    
+    static var stub1: CameraInformation.CameraFixedInformationResponse {
+        .init(
+            manufacturer: "",
+            productName: "",
+            guid: "",
+            serialNumber: "",
+            macAddress: "",
+            firmwareVersion: ""
+        )
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/CameraConnectionView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/CameraConnectionView.swift
@@ -44,7 +44,7 @@ struct CameraConnectionView: View {
             .frame(width: 300, height: 115)
     }
     
-    private func connectButtonView(type: connectionType) -> some View {
+    private func connectButtonView(type: ConnectionType) -> some View {
         NavigationLink {
             ConnectionGuideView(type: type)
         } label: {

--- a/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/ConnectionCompletionView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/ConnectionCompletionView.swift
@@ -13,15 +13,13 @@ struct ConnectionCompletionView: View {
     
     @Environment(\.dismiss) var dismiss
     
-    @State private var cameraName: String = "Canon R6"
-    
     var body: some View {
         VStack {
             connectImageView()
                 .padding(.top, 75)
                 .padding(.bottom, 38)
             
-            Text("\(cameraName)")
+            Text("\(cameraConnectionManager.productName)")
                 .font(.title1)
                 .foregroundStyle(Color.g0)
                 .padding(.bottom, 14)
@@ -63,12 +61,14 @@ struct ConnectionCompletionView: View {
             Text("Start Tri-shot")
                 .font(.num3)
                 .foregroundStyle(Color.g12)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(Color.g0)
+                .cornerRadius(62)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 16)
-        .background(Color.g0)
-        .cornerRadius(62)
+        .padding(.horizontal, 16)
     }
+    
 }
 
 #Preview {

--- a/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/ConnectionGuideView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/ConnectionGuideView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ConnectionGuideView: View {
-    var type: connectionType
+    var type: ConnectionType
     
     @State private var ipAddress: String = ""
     @EnvironmentObject var cameraConnectionManager: CameraConnectionManager
@@ -125,7 +125,7 @@ struct ConnectionGuideView: View {
             Text("Disconnected")
                 .foregroundColor(.gray)
         case .connecting:
-            Text("Disconnected")
+            Text("Connecting")
                 .foregroundColor(.gray)
         case .connected:
             Text("Connected")

--- a/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/Error/ConnectionError.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/Error/ConnectionError.swift
@@ -31,9 +31,9 @@ extension ConnectionError {
     static func from(_ error: Error) -> ConnectionError {
         if let ccapiError = error as? CCAPIError {
             switch ccapiError {
-            case .authenticationFailed:
+            case .authenticationFailed(_):
                 return .authenticationFailed
-            case .deviceUnavailable:
+            case .deviceUnavailable(_):
                 return .cameraBusy
             default:
                 return .generic(ccapiError.localizedDescription)

--- a/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/Shared/ConnectionType.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/Shared/ConnectionType.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-enum connectionType {
+enum ConnectionType {
     case bluetooth
     case ip
     

--- a/HonestHouse/HonestHouse/Sources/Presentation/Main/View/MainView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Main/View/MainView.swift
@@ -12,7 +12,6 @@ struct MainView: View {
     //TODO: App 파일에서 주입하도록 설정
     @EnvironmentObject private var container: DIContainer
     @EnvironmentObject var cameraConnectionManager: CameraConnectionManager
-    @Environment(\.modelContext) private var modelContext
     
     @State var vm: MainViewModel
     @State var isPresetEditMode: Bool = false

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/CustomWheelPicker.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/CustomWheelPicker.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(iOS 18.0, *)
 struct CustomWheelPicker<SelectionValue, Content>: View where SelectionValue: Hashable & Sendable, Content: View {
     // MARK: Properties
     @State private var scrollPosition: ScrollPosition = .init(idType: SelectionValue.self)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/CustomWheelPickerView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/CustomWheelPickerView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(iOS 18.0, *)
 struct CustomWheelPickerView: View {
     // MARK: Properties
     @State private var selectedAperture: String = ApertureData.defaultAperture
@@ -71,5 +72,7 @@ struct CustomWheelPickerView: View {
 }
 
 #Preview {
-    CustomWheelPickerView()
+    if #available(iOS 18.0, *) {
+        CustomWheelPickerView()
+    } else { }
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #이슈번호

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 카메라 정보를 요청하는 API 코드 구현
- 앱 기능(프리셋, 트라이샷, 아카이빙)을 시작하기 전에 카메라가 앱과 연결됐는지 확인하는 로직 구현

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://github.com/user-attachments/assets/0bb7852c-3b68-4842-a633-f75c5d53f09c">

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

### 카메라가 연결됐는지 확인은 어떻게 할까요?
- 트라이샷, 프리셋, 아카이빙 뷰 내에서 컴포넌트가 탭 될 때 연결이 됐는지 확인하는 로직을 실행합니다.
- 왜냐하면 카메라 연결이 유지돼있어야 네트워크 통신을 할 수 있기 때문..!
- 연결 확인됐는지 확인하는 방식은, 가장 간단한 요청인 `CameraInformation`을 GET 하는 요청을 보내는 것입니다. response가 되면 연결 된거, error가 throw 되면 연결이 안 된 것입니다.

### 사용 방법
아래 메서드를 호출하고 Bool값을 반환 받습니다.
```
// CameraConnectionManager.swift
    func checkConnectionStatus() async -> Bool {
        do {
            _ = try await getCameraInfo(with: .ver100)
            self.connectionState = .connected
            return true
        } catch {
            self.connectionState = .disconnected
            return false
        }
    }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카메라 인증 후 자동으로 기기 정보를 조회해 제품명(모델명)을 앱에 표시합니다.
  * 연결 상태를 확인하는 기능이 추가되어 연결/비연결 여부를 더 정확히 판별합니다.

* **버그 수정**
  * 연결 상태 표기가 "Disconnected"에서 연결 중 상태에 맞게 "Connecting"으로 수정되었습니다.

* **개선 사항**
  * 연결 완료 화면과 연결 버튼의 레이아웃·스타일을 개선해 가독성과 터치 편의성을 향상시켰습니다.
  * 일부 컴포넌트의 iOS 18 가용성 표기를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->