### PR TITLE
Feat: #80 Preset 생성/조회 기능 연결과 PresetView 화면 구현

### DIFF
--- a/HonestHouse/HonestHouse/Sources/Core/Managers/PresetManager.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Managers/PresetManager.swift
@@ -125,7 +125,7 @@ final class PresetManager: PresetManagerType {
         try saveContext()
         
         Logger.info("✅ Preset created successfully: \(preset.name) (id: \(preset.id))", category: .coreData)
-        logPresetDetails(preset)
+//        logPresetDetails(preset)
     }
     
     /// Preset 업데이트
@@ -145,7 +145,7 @@ final class PresetManager: PresetManagerType {
         try saveContext()
         
         Logger.info("✅ Preset updated successfully: \(preset.name) (id: \(preset.id))", category: .coreData)
-        logPresetDetails(preset)
+//        logPresetDetails(preset)
     }
     
     /// Preset 삭제

--- a/HonestHouse/HonestHouse/Sources/Core/Managers/PresetManager.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Managers/PresetManager.swift
@@ -21,6 +21,7 @@ final class PresetManager: PresetManagerType {
         request.sortDescriptors = [NSSortDescriptor(keyPath: \PresetEntity.createdAt, ascending: true)]
         
         let entities = try viewContext.fetch(request)
+        Logger.debug("Fetched \(entities.count) presets from CoreData", category: .coreData)
         return entities.map { $0.toPreset() }
     }
     
@@ -31,7 +32,12 @@ final class PresetManager: PresetManagerType {
         request.fetchLimit = 1
         
         let entities = try viewContext.fetch(request)
-        return entities.first?.toPreset()
+        if let preset = entities.first?.toPreset() {
+            Logger.debug("Fetched preset: \(preset.name) (id: \(id))", category: .coreData)
+            return preset
+        }
+        Logger.warning("Preset not found with id: \(id)", category: .coreData)
+        return nil
     }
 
     /// 모든 SelectedPreset 조회 (order 기준 오름차순)
@@ -102,6 +108,8 @@ final class PresetManager: PresetManagerType {
     /// ### 새 Preset 생성
     /// 총 프리셋이 3개 미만인 경우 자동적으로 selectedPresetEntity가 된다.
     func createPreset(_ preset: Preset) throws {
+        Logger.info("Creating preset: \(preset.name)", category: .coreData)
+        
         let entity = PresetEntity(context: viewContext)
         updateEntityFromPreset(entity, preset: preset)
 
@@ -115,10 +123,15 @@ final class PresetManager: PresetManagerType {
         }
 
         try saveContext()
+        
+        Logger.info("✅ Preset created successfully: \(preset.name) (id: \(preset.id))", category: .coreData)
+        logPresetDetails(preset)
     }
     
     /// Preset 업데이트
     func updatePreset(_ preset: Preset) throws {
+        Logger.info("Updating preset: \(preset.name)", category: .coreData)
+        
         let request = PresetEntity.fetchRequest()
         request.predicate = NSPredicate(format: "id == %@", preset.id as CVarArg)
         request.fetchLimit = 1
@@ -130,6 +143,9 @@ final class PresetManager: PresetManagerType {
         updateEntityFromPreset(entity, preset: preset)
         
         try saveContext()
+        
+        Logger.info("✅ Preset updated successfully: \(preset.name) (id: \(preset.id))", category: .coreData)
+        logPresetDetails(preset)
     }
     
     /// Preset 삭제
@@ -139,6 +155,8 @@ final class PresetManager: PresetManagerType {
     
     /// ID로 Preset 삭제
     func deletePreset(by id: UUID) throws {
+        Logger.info("Deleting preset with id: \(id)", category: .coreData)
+        
         let request = PresetEntity.fetchRequest()
         request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
         request.fetchLimit = 1
@@ -150,6 +168,8 @@ final class PresetManager: PresetManagerType {
         viewContext.delete(entity)
         
         try saveContext()
+        
+        Logger.info("✅ Preset deleted successfully (id: \(id))", category: .coreData)
     }
     
     /// Preset → PresetEntity 변환 (업데이트용)
@@ -158,15 +178,40 @@ final class PresetManager: PresetManagerType {
         entity.name = preset.name
         entity.pictureStyle = preset.pictureStyle.rawValue
         entity.shootingMode = preset.shootingMode.rawValue
+        
+        // 옵셔널 String → 옵셔널 String (nil 허용)
         entity.aperture = preset.aperture
         entity.shutterSpeed = preset.shutterSpeed
         entity.iso = preset.iso
         entity.exposureCompensation = preset.exposureCompensation
+        
+        // Int? → Int16 (nil일 경우 0으로 저장)
         entity.colorTemperature = preset.colorTemperature.map { Int16($0) } ?? 0
         entity.tintBlueAmber = preset.tintBlueAmber.map { Int16($0) } ?? 0
         entity.tintMagentaGreen = preset.tintMagentaGreen.map { Int16($0) } ?? 0
+        
         entity.createdAt = preset.createdAt
         entity.updatedAt = preset.updatedAt
+    }
+    
+    /// Preset 상세 정보 로깅
+    private func logPresetDetails(_ preset: Preset) {
+        Logger.debug("""
+        📋 Preset Details:
+          - Name: \(preset.name)
+          - ID: \(preset.id)
+          - PictureStyle: \(preset.pictureStyle.rawValue)
+          - ShootingMode: \(preset.shootingMode.rawValue)
+          - Aperture: \(preset.aperture ?? "nil")
+          - ShutterSpeed: \(preset.shutterSpeed ?? "nil")
+          - ISO: \(preset.iso ?? "nil")
+          - ExposureCompensation: \(preset.exposureCompensation ?? "nil")
+          - ColorTemperature: \(preset.colorTemperature?.description ?? "nil")
+          - TintBlueAmber: \(preset.tintBlueAmber?.description ?? "nil")
+          - TintMagentaGreen: \(preset.tintMagentaGreen?.description ?? "nil")
+          - CreatedAt: \(preset.createdAt)
+          - UpdatedAt: \(preset.updatedAt)
+        """, category: .coreData)
     }
     
     /// Context 저장
@@ -174,13 +219,18 @@ final class PresetManager: PresetManagerType {
         if viewContext.hasChanges {
             do {
                 try viewContext.save()
+                Logger.debug("💾 CoreData context saved successfully", category: .coreData)
             } catch {
+                Logger.error("❌ Failed to save CoreData context: \(error.localizedDescription)", category: .coreData)
                 throw PresetManagerError.saveFailed(error)
             }
+        } else {
+            Logger.debug("No changes in CoreData context", category: .coreData)
         }
     }
 }
 
+// MARK: - Stub Implementation
 final class StubPresetManager: PresetManagerType {
     private var presets: [Preset] = [.stub1, .stub2, .stub3]
     private var activatedPresets: Set<UUID> = [Preset.stub1.id, Preset.stub2.id, Preset.stub3.id]

--- a/HonestHouse/HonestHouse/Sources/Core/Model/Preset.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Model/Preset.swift
@@ -176,7 +176,7 @@ extension Preset {
     static var stub2: Preset {
         .init(
             id: .init(),
-            name: "프리셋2",
+            name: "프리셋2프리셋2프리셋2프리셋2프리셋2프리셋2프리셋2프리셋2프리셋2",
             pictureStyle: .faithful,
             shootingMode: .p,
             aperture: "10",

--- a/HonestHouse/HonestHouse/Sources/Core/Model/Preset.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Model/Preset.swift
@@ -74,6 +74,7 @@ struct Preset: Hashable, Identifiable {
     }
 }
 
+// MARK: - Equatable & Hashable
 extension Preset {
     static func == (lhs: Preset, rhs: Preset) -> Bool {
         lhs.id == rhs.id
@@ -84,6 +85,7 @@ extension Preset {
     }
 }
 
+// MARK: - UI Description
 extension Preset {
     // TODO: 추후 UIAdapter 등으로 분리 요망
     var modeDescription: String? {
@@ -104,6 +106,54 @@ extension Preset {
     }
 }
 
+// MARK: - Display Formatting
+extension Preset {
+    /// 뷰에서 표시할 조리개 값
+    var displayAperture: String {
+        aperture ?? "Auto"
+    }
+    
+    /// 뷰에서 표시할 셔터스피드 값
+    var displayShutterSpeed: String {
+        shutterSpeed ?? "Auto"
+    }
+    
+    /// 뷰에서 표시할 ISO 값
+    var displayISO: String {
+        iso ?? "Auto"
+    }
+    
+    /// 뷰에서 표시할 노출 보정 값
+    var displayExposureCompensation: String {
+        exposureCompensation ?? "0"
+    }
+    
+    /// 뷰에서 표시할 색온도 값
+    var displayColorTemperature: String {
+        if let temp = colorTemperature {
+            return "\(temp)K"
+        }
+        return "Auto"
+    }
+    
+    /// 뷰에서 표시할 Tint Blue-Amber 값
+    var displayTintBlueAmber: String {
+        if let tint = tintBlueAmber {
+            return "\(tint)"
+        }
+        return "0"
+    }
+    
+    /// 뷰에서 표시할 Tint Magenta-Green 값
+    var displayTintMagentaGreen: String {
+        if let tint = tintMagentaGreen {
+            return "\(tint)"
+        }
+        return "0"
+    }
+}
+
+// MARK: - Stub Data
 extension Preset {
     static var stub1: Preset {
         .init(
@@ -159,4 +209,3 @@ extension Preset {
         )
     }
 }
-

--- a/HonestHouse/HonestHouse/Sources/Core/Model/Preset.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Model/Preset.swift
@@ -74,7 +74,7 @@ struct Preset: Hashable, Identifiable {
     }
 }
 
-// MARK: - Equatable & Hashable
+// Equatable & Hashable
 extension Preset {
     static func == (lhs: Preset, rhs: Preset) -> Bool {
         lhs.id == rhs.id
@@ -85,7 +85,7 @@ extension Preset {
     }
 }
 
-// MARK: - UI Description
+// UI Description
 extension Preset {
     // TODO: 추후 UIAdapter 등으로 분리 요망
     var modeDescription: String? {
@@ -106,7 +106,7 @@ extension Preset {
     }
 }
 
-// MARK: - Display Formatting
+// Display Formatting
 extension Preset {
     /// 뷰에서 표시할 조리개 값
     var displayAperture: String {
@@ -153,7 +153,7 @@ extension Preset {
     }
 }
 
-// MARK: - Stub Data
+// Stub Data
 extension Preset {
     static var stub1: Preset {
         .init(

--- a/HonestHouse/HonestHouse/Sources/General/Logger.swift
+++ b/HonestHouse/HonestHouse/Sources/General/Logger.swift
@@ -33,6 +33,7 @@ enum LogCategory: String {
     case connection = "Connection"
     case ui = "UI"
     case viewModel = "ViewModel"
+    case coreData = "CoreData"
     case general = "General"
     
     var osLog: OSLog {
@@ -63,7 +64,30 @@ struct Logger {
         
         os_log("%{public}@", log: category.osLog, type: level.osLogType, logMessage)
     }
+    
+    // MARK: - Convenience Methods
+    static func debug(_ message: String, category: LogCategory = .general) {
+        log(.debug, category: category, message: message)
+    }
+    
+    static func info(_ message: String, category: LogCategory = .general) {
+        log(.info, category: category, message: message)
+    }
+    
+    static func warning(_ message: String, category: LogCategory = .general) {
+        log(.warning, category: category, message: message)
+    }
+    
+    static func error(_ message: String, category: LogCategory = .general) {
+        log(.error, category: category, message: message)
+    }
 }
 
-
-
+// MARK: - DateFormatter Extension
+private extension DateFormatter {
+    static func logTimestamp() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SSS"
+        return formatter.string(from: Date())
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/General/Logger.swift
+++ b/HonestHouse/HonestHouse/Sources/General/Logger.swift
@@ -64,30 +64,4 @@ struct Logger {
         
         os_log("%{public}@", log: category.osLog, type: level.osLogType, logMessage)
     }
-    
-    // MARK: - Convenience Methods
-    static func debug(_ message: String, category: LogCategory = .general) {
-        log(.debug, category: category, message: message)
-    }
-    
-    static func info(_ message: String, category: LogCategory = .general) {
-        log(.info, category: category, message: message)
-    }
-    
-    static func warning(_ message: String, category: LogCategory = .general) {
-        log(.warning, category: category, message: message)
-    }
-    
-    static func error(_ message: String, category: LogCategory = .general) {
-        log(.error, category: category, message: message)
-    }
-}
-
-// MARK: - DateFormatter Extension
-private extension DateFormatter {
-    static func logTimestamp() -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm:ss.SSS"
-        return formatter.string(from: Date())
-    }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/CameraConstants.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/CameraConstants.swift
@@ -17,7 +17,7 @@ struct CameraConstants {
     static let pictureStyleValues: [String] = ["auto", "standard", "portrait", "landscape", "finedetail", "neutral", "faithful", "monochrome"]
     
     static let tintMagentaGreenValues: [Int] = [-8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8]
-    static let exposureCompensationValues: [Int] = [-9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    static let exposureCompensationValues: [String] = ["-3.0", "-2_2/3", "-2_1/3", "-2.0", "-1_2/3", "-1_1/3", "-1.0", "-0_2/3", "-0_1/3", "+0.0", "+0_1/3", "+0_2/3", "+1.0", "+1_1/3", "+1_2/3", "+2.0", "+2_1/3", "+2_2/3", "+3.0"]
     static let colorTemperatureValues: [Int] = [2500, 2600, 2700, 2800, 2900, 3000, 3100, 3200, 3300, 3400, 3500, 3600, 3700, 3800, 3900, 4000, 4100, 4200, 4300, 4400, 4500, 4600, 4700, 4800, 4900, 5000, 5100, 5200, 5300, 5400, 5500, 5600, 5700, 5800, 5900, 6000, 6100, 6200, 6300, 6400, 6500, 6600, 6700, 6800, 6900, 7000, 7100, 7200, 7300, 7400, 7500, 7600, 7700, 7800, 7900, 8000, 8100, 8200, 8300, 8400, 8500, 8600, 8700, 8800, 8900, 9000, 9100, 9200, 9300, 9400, 9500, 9600, 9700, 9800, 9900, 10000]
     
     static let exposureCompensationRange: ClosedRange<Int> = -9...9     // min ~ max

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/CustomWheelPickerView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/CustomWheelPickerView.swift
@@ -14,7 +14,7 @@ struct Config {
 
 struct CustomWheelPickerView<SelectionValue>: View where SelectionValue: Hashable & Sendable {
 
-    @Binding var selectedValue: SelectionValue
+    @Binding var selectedValue: SelectionValue?
     let items: [SelectionValue]
     let config: Config
     
@@ -25,12 +25,16 @@ struct CustomWheelPickerView<SelectionValue>: View where SelectionValue: Hashabl
                 selection: $selectedValue,
                 config: config
             ) { value in
-                Text("\(value)")
-                    .font(.num4)
-                    .foregroundStyle(value == selectedValue ? Color.yellow1 : Color.g0)
-                    .animation(.easeInOut(duration: 0.2), value: selectedValue)
-                    .frame(width: config.itemSize.width,
-                           height: config.itemSize.height)
+                
+                if let value = value {
+                    
+                    Text("\(value)")
+                        .font(.num4)
+                        .foregroundStyle(value == selectedValue ? Color.yellow1 : Color.g0)
+                        .animation(.easeInOut(duration: 0.2), value: selectedValue)
+                        .frame(width: config.itemSize.width,
+                               height: config.itemSize.height)
+                }
             }
             .frame(height: 52)
             .overlay {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/CustomWheelPickerView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/CustomWheelPickerView.swift
@@ -12,6 +12,8 @@ struct Config {
     var itemSize: CGSize
 }
 
+
+// TODO: 데이터 옵셔널 케이스 처리해서 하나로 합칠 예정
 struct CustomWheelPickerView<SelectionValue>: View where SelectionValue: Hashable & Sendable {
 
     @Binding var selectedValue: SelectionValue?
@@ -27,7 +29,6 @@ struct CustomWheelPickerView<SelectionValue>: View where SelectionValue: Hashabl
             ) { value in
                 
                 if let value = value {
-                    
                     Text("\(value)")
                         .font(.num4)
                         .foregroundStyle(value == selectedValue ? Color.yellow1 : Color.g0)
@@ -38,6 +39,7 @@ struct CustomWheelPickerView<SelectionValue>: View where SelectionValue: Hashabl
             }
             .frame(height: 52)
             .overlay {
+                
                 VStack {
                     Rectangle()
                         .frame(width: 1, height: 8)
@@ -71,6 +73,25 @@ struct CustomWheelPickerView<SelectionValue>: View where SelectionValue: Hashabl
                     .allowsHitTesting(false)
             }
         }
+    }
+}
+
+struct NonOptionalWheelPickerView<SelectionValue>: View
+where SelectionValue: Hashable & Sendable {
+    @Binding var selectedValue: SelectionValue  // Non-Optional
+    let items: [SelectionValue]
+    let config: Config
+    
+    var body: some View {
+        // Optional로 변환해서 기존 CustomWheelPickerView 재사용
+        CustomWheelPickerView(
+            selectedValue: Binding(
+                get: { self.selectedValue },
+                set: { self.selectedValue = $0 ?? self.selectedValue }
+            ),
+            items: items,
+            config: config
+        )
     }
 }
 

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetGridItem.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetGridItem.swift
@@ -1,0 +1,99 @@
+//
+//  PresetGridItem.swift
+//  HonestHouse
+//
+//  Created by Subeen on 11/6/25.
+//
+
+import SwiftUI
+
+struct PresetGridItem: View {
+    let preset: Preset
+    let isSelected: Bool
+    let isEditMode: Bool
+    let onTap: () -> Void
+    let onActionTap: () -> Void
+    
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: 12) {
+                // 상단: 제목과 액션 버튼
+                HStack {
+                    Text(preset.name)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(.white)
+                        .lineLimit(1)
+                    
+                    Spacer()
+                    
+                    if !isEditMode {
+                        Button(action: onActionTap) {
+                            Image(systemName: "circle")
+                                .font(.system(size: 20))
+                                .foregroundColor(.white.opacity(0.7))
+                        }
+                    }
+                }
+                
+                Spacer()
+                
+                // 중앙: 모드 정보
+                if let modeDescription = preset.modeDescription {
+                    Text(modeDescription)
+                        .font(.system(size: 12))
+                        .foregroundColor(.white.opacity(0.8))
+                }
+                
+                // ISO 정보
+                Text(preset.isoDescription)
+                    .font(.system(size: 12))
+                    .foregroundColor(.white.opacity(0.8))
+                
+                Spacer()
+                
+                // 하단: 아이콘들
+                HStack(spacing: 8) {
+                    ForEach(["tv", "mic", "pencil", "square.and.arrow.up"], id: \.self) { icon in
+                        Image(systemName: icon)
+                            .font(.system(size: 14))
+                            .foregroundColor(.white.opacity(0.6))
+                    }
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity)
+            .aspectRatio(1, contentMode: .fit)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.black.opacity(0.8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(isSelected ? Color.blue : Color.clear, lineWidth: 2)
+                    )
+            )
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+#Preview {
+    HStack(spacing: 10) {
+        PresetGridItem(
+            preset: .stub1,
+            isSelected: false,
+            isEditMode: false,
+            onTap: {},
+            onActionTap: {}
+        )
+        
+        PresetGridItem(
+            preset: .stub2,
+            isSelected: true,
+            isEditMode: false,
+            onTap: {},
+            onActionTap: {}
+        )
+    }
+    .padding()
+    .background(Color.gray)
+}

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetGridItem.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetGridItem.swift
@@ -16,63 +16,35 @@ struct PresetGridItem: View {
     
     var body: some View {
         Button(action: onTap) {
-            VStack(alignment: .leading, spacing: 12) {
-                // 상단: 제목과 액션 버튼
-                HStack {
-                    Text(preset.name)
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundColor(.white)
-                        .lineLimit(1)
-                    
-                    Spacer()
-                    
-                    if !isEditMode {
-                        Button(action: onActionTap) {
-                            Image(systemName: "circle")
-                                .font(.system(size: 20))
-                                .foregroundColor(.white.opacity(0.7))
-                        }
-                    }
-                }
-                
+            VStack(spacing: 16) {
+                nameView()
                 Spacer()
-                
-                // 중앙: 모드 정보
-                if let modeDescription = preset.modeDescription {
-                    Text(modeDescription)
-                        .font(.system(size: 12))
-                        .foregroundColor(.white.opacity(0.8))
-                }
-                
-                // ISO 정보
-                Text(preset.isoDescription)
-                    .font(.system(size: 12))
-                    .foregroundColor(.white.opacity(0.8))
-                
-                Spacer()
-                
-                // 하단: 아이콘들
-                HStack(spacing: 8) {
-                    ForEach(["tv", "mic", "pencil", "square.and.arrow.up"], id: \.self) { icon in
-                        Image(systemName: icon)
-                            .font(.system(size: 14))
-                            .foregroundColor(.white.opacity(0.6))
-                    }
-                }
+                applyButtonView()
             }
-            .padding(12)
-            .frame(maxWidth: .infinity)
-            .aspectRatio(1, contentMode: .fit)
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.black.opacity(0.8))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(isSelected ? Color.blue : Color.clear, lineWidth: 2)
-                    )
-            )
+            .padding(.vertical, 20)
+            .frame(maxHeight: 122)
+            .background(Color.g11)
+            .clipShape(RoundedRectangle(cornerRadius: 20))
         }
-        .buttonStyle(PlainButtonStyle())
+        .buttonStyle(NoHighlightButtonStyle())
+    }
+    
+    func nameView() -> some View {
+        Text("\(preset.name)")
+            .font(.num6)
+            .multilineTextAlignment(.center)
+            .lineLimit(2)
+            .foregroundStyle(Color.g0)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 16)
+    }
+    
+    func applyButtonView() -> some View {
+        Button(action: onActionTap) {
+            Image(systemName: "circle")
+                .font(.system(size: 24))
+                .foregroundColor(.white.opacity(0.7))
+        }
     }
 }
 

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetGridItemView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetGridItemView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct PresetGridItem: View {
+struct PresetGridItemView: View {
     let preset: Preset
     let isSelected: Bool
     let isEditMode: Bool
@@ -50,7 +50,7 @@ struct PresetGridItem: View {
 
 #Preview {
     HStack(spacing: 10) {
-        PresetGridItem(
+        PresetGridItemView(
             preset: .stub1,
             isSelected: false,
             isEditMode: false,
@@ -58,7 +58,7 @@ struct PresetGridItem: View {
             onActionTap: {}
         )
         
-        PresetGridItem(
+        PresetGridItemView(
             preset: .stub2,
             isSelected: true,
             isEditMode: false,

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetListItemView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetListItemView.swift
@@ -1,0 +1,106 @@
+//
+//  PresetListItemView.swift
+//  HonestHouse
+//
+//  Created by Subeen on 11/6/25.
+//
+
+import SwiftUI
+
+struct PresetListItem: View {
+    let preset: Preset
+    let isSelected: Bool
+    let isEditMode: Bool
+    let onTap: () -> Void
+    let onActionTap: () -> Void
+    
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 16) {
+                // 좌측: 프리셋 정보
+                VStack(alignment: .leading, spacing: 8) {
+                    // 제목
+                    Text(preset.name)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.white)
+                    
+                    // 촬영 설정 정보
+                    HStack(spacing: 12) {
+                        // 아이콘 그룹
+                        HStack(spacing: 6) {
+                            ForEach(["tv", "mic", "pencil", "square.and.arrow.up"], id: \.self) { icon in
+                                Image(systemName: icon)
+                                    .font(.system(size: 12))
+                                    .foregroundColor(.white.opacity(0.6))
+                            }
+                        }
+                        
+                        Spacer()
+                        
+                        // 모드와 ISO 정보
+                        HStack(spacing: 8) {
+                            if let modeDescription = preset.modeDescription {
+                                Text(modeDescription)
+                                    .font(.system(size: 13))
+                                    .foregroundColor(.white.opacity(0.8))
+                            }
+                            
+                            Text(preset.isoDescription)
+                                .font(.system(size: 13))
+                                .foregroundColor(.white.opacity(0.8))
+                        }
+                    }
+                }
+                
+                // 우측: 액션 버튼
+                if !isEditMode {
+                    Button(action: onActionTap) {
+                        Image(systemName: "circle")
+                            .font(.system(size: 24))
+                            .foregroundColor(.white.opacity(0.7))
+                    }
+                }
+            }
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.black.opacity(0.8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(isSelected ? Color.blue : Color.clear, lineWidth: 2)
+                    )
+            )
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+#Preview {
+    VStack(spacing: 10) {
+        PresetListItem(
+            preset: .stub1,
+            isSelected: false,
+            isEditMode: false,
+            onTap: {},
+            onActionTap: {}
+        )
+        
+        PresetListItem(
+            preset: .stub2,
+            isSelected: true,
+            isEditMode: false,
+            onTap: {},
+            onActionTap: {}
+        )
+        
+        PresetListItem(
+            preset: .stub3,
+            isSelected: false,
+            isEditMode: true,
+            onTap: {},
+            onActionTap: {}
+        )
+    }
+    .padding()
+    .background(Color.gray)
+}

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetListItemView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetListItemView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct PresetListItem: View {
+struct PresetListItemView: View {
     let preset: Preset
     let isSelected: Bool
     let isEditMode: Bool
@@ -15,31 +15,26 @@ struct PresetListItem: View {
     let onActionTap: () -> Void
     
     var body: some View {
-        Button(action: onTap) {
-            HStack {
-                Spacer()
-                VStack(alignment: .center, spacing: 12) {
-                    
-                    nameView()
-                    iconListView()
-                    settingDescriptionView()
-                    
-                }
-                Spacer()
-                applyButtonView()
-                
+        HStack {
+            Spacer()
+            VStack(alignment: .center, spacing: 12) {
+                nameView()
+                iconListView()
+                settingDescriptionView()
             }
-            
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 15)
-            .padding(.trailing, 8)
-            .background(Color.g11)
-            .clipShape(
-                RoundedRectangle(cornerRadius: 100)
-                    
-            )
+            Spacer()
+            applyButtonView()
         }
-        .buttonStyle(NoHighlightButtonStyle())
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 15)
+        .padding(.trailing, 8)
+        .background(Color.g11)
+        .clipShape(
+            RoundedRectangle(cornerRadius: 100)
+        )
+        .onTapGesture {
+            onTap()
+        }
     }
     
     func nameView() -> some View {
@@ -67,7 +62,7 @@ struct PresetListItem: View {
             }
             
             Text(preset.isoDescription)
-               
+            
         }
         .font(.num6)
         .foregroundStyle(Color.g0)
@@ -84,7 +79,7 @@ struct PresetListItem: View {
 
 #Preview {
     VStack(spacing: 20) {
-        PresetListItem(
+        PresetListItemView(
             preset: .stub1,
             isSelected: false,
             isEditMode: false,
@@ -92,7 +87,7 @@ struct PresetListItem: View {
             onActionTap: {}
         )
         
-        PresetListItem(
+        PresetListItemView(
             preset: .stub2,
             isSelected: true,
             isEditMode: false,
@@ -100,7 +95,7 @@ struct PresetListItem: View {
             onActionTap: {}
         )
         
-        PresetListItem(
+        PresetListItemView(
             preset: .stub3,
             isSelected: false,
             isEditMode: true,

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetListItemView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetListItemView.swift
@@ -20,7 +20,7 @@ struct PresetListItem: View {
                 Spacer()
                 VStack(alignment: .center, spacing: 12) {
                     
-                    titleView()
+                    nameView()
                     iconListView()
                     settingDescriptionView()
                     
@@ -42,15 +42,16 @@ struct PresetListItem: View {
         .buttonStyle(NoHighlightButtonStyle())
     }
     
-    func titleView() -> some View {
+    func nameView() -> some View {
         Text(preset.name)
             .font(.num6)
             .foregroundColor(.white)
+            .lineLimit(1)
+            .padding(.horizontal, 40)
     }
     
     func iconListView() -> some View {
         HStack(spacing: 4) {
-            Circle().frame(width: 32, height: 32)
             Circle().frame(width: 32, height: 32)
             Circle().frame(width: 32, height: 32)
             Circle().frame(width: 32, height: 32)
@@ -78,7 +79,6 @@ struct PresetListItem: View {
                 .font(.system(size: 24))
                 .foregroundColor(.white.opacity(0.7))
         }
-
     }
 }
 

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetListItemView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetListItemView.swift
@@ -16,67 +16,74 @@ struct PresetListItem: View {
     
     var body: some View {
         Button(action: onTap) {
-            HStack(spacing: 16) {
-                // 좌측: 프리셋 정보
-                VStack(alignment: .leading, spacing: 8) {
-                    // 제목
-                    Text(preset.name)
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(.white)
+            HStack {
+                Spacer()
+                VStack(alignment: .center, spacing: 12) {
                     
-                    // 촬영 설정 정보
-                    HStack(spacing: 12) {
-                        // 아이콘 그룹
-                        HStack(spacing: 6) {
-                            ForEach(["tv", "mic", "pencil", "square.and.arrow.up"], id: \.self) { icon in
-                                Image(systemName: icon)
-                                    .font(.system(size: 12))
-                                    .foregroundColor(.white.opacity(0.6))
-                            }
-                        }
-                        
-                        Spacer()
-                        
-                        // 모드와 ISO 정보
-                        HStack(spacing: 8) {
-                            if let modeDescription = preset.modeDescription {
-                                Text(modeDescription)
-                                    .font(.system(size: 13))
-                                    .foregroundColor(.white.opacity(0.8))
-                            }
-                            
-                            Text(preset.isoDescription)
-                                .font(.system(size: 13))
-                                .foregroundColor(.white.opacity(0.8))
-                        }
-                    }
+                    titleView()
+                    iconListView()
+                    settingDescriptionView()
+                    
                 }
+                Spacer()
+                applyButtonView()
                 
-                // 우측: 액션 버튼
-                if !isEditMode {
-                    Button(action: onActionTap) {
-                        Image(systemName: "circle")
-                            .font(.system(size: 24))
-                            .foregroundColor(.white.opacity(0.7))
-                    }
-                }
             }
-            .padding(16)
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.black.opacity(0.8))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(isSelected ? Color.blue : Color.clear, lineWidth: 2)
-                    )
+            
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 15)
+            .padding(.trailing, 8)
+            .background(Color.g11)
+            .clipShape(
+                RoundedRectangle(cornerRadius: 100)
+                    
             )
         }
-        .buttonStyle(PlainButtonStyle())
+        .buttonStyle(NoHighlightButtonStyle())
+    }
+    
+    func titleView() -> some View {
+        Text(preset.name)
+            .font(.num6)
+            .foregroundColor(.white)
+    }
+    
+    func iconListView() -> some View {
+        HStack(spacing: 4) {
+            Circle().frame(width: 32, height: 32)
+            Circle().frame(width: 32, height: 32)
+            Circle().frame(width: 32, height: 32)
+            Circle().frame(width: 32, height: 32)
+            Circle().frame(width: 32, height: 32)
+            Circle().frame(width: 32, height: 32)
+        }
+    }
+    
+    func settingDescriptionView() -> some View {
+        HStack(spacing: 8) {
+            if let modeDescription = preset.modeDescription {
+                Text(modeDescription)
+            }
+            
+            Text(preset.isoDescription)
+               
+        }
+        .font(.num6)
+        .foregroundStyle(Color.g0)
+    }
+    
+    func applyButtonView() -> some View {
+        Button(action: onActionTap) {
+            Image(systemName: "circle")
+                .font(.system(size: 24))
+                .foregroundColor(.white.opacity(0.7))
+        }
+
     }
 }
 
 #Preview {
-    VStack(spacing: 10) {
+    VStack(spacing: 20) {
         PresetListItem(
             preset: .stub1,
             isSelected: false,

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetViewMode.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/PresetViewMode.swift
@@ -1,0 +1,31 @@
+//
+//  PresetViewMode.swift
+//  HonestHouse
+//
+//  Created by Subeen on 11/6/25.
+//
+
+import Foundation
+
+enum PresetViewMode: String, CaseIterable {
+    case grid = "그리드"
+    case list = "리스트"
+    
+    var iconName: String {
+        switch self {
+        case .grid:
+            return "square.grid.2x2"
+        case .list:
+            return "list.bullet"
+        }
+    }
+    
+    var alternativeIconName: String {
+        switch self {
+        case .grid:
+            return "rectangle.grid.1x2"
+        case .list:
+            return "square.grid.2x2"
+        }
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/SettingButton.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/SettingButton.swift
@@ -83,6 +83,7 @@ struct SettingButton<SelectionType>: View {
             
             .disabled(!isInteractive)
             .animation(.easeInOut(duration: 0.15), value: isSelected)
+            .buttonStyle(NoHighlightButtonStyle())
         }
     }
     
@@ -121,89 +122,5 @@ struct ShootingModeSelector: View {
                 }
             }
         }
-    }
-}
-
-// TODO : 삭제 예정
-struct ValueSlider: View {
-    let title: String
-    @Binding var selectedIndex: Int
-    let values: [String]
-    let isEnabled: Bool
-    let onValueChange: (Int) -> Void
-    
-    @State private var dragOffset: CGFloat = 0
-    @GestureState private var isDragging: Bool = false
-    
-    private let itemWidth: CGFloat = 70
-    private let itemSpacing: CGFloat = 5
-    
-    var body: some View {
-        VStack(spacing: 0) {
-            // Slider Track
-            GeometryReader { geometry in
-                let totalWidth = CGFloat(values.count - 1) * (itemWidth + itemSpacing)
-                let centerX = geometry.size.width / 2
-                
-                HStack(spacing: itemSpacing) {
-                    ForEach(Array(values.enumerated()), id: \.offset) { index, value in
-                        Text(value)
-                            .font(.system(size: index == selectedIndex ? 16 : 12))
-                            .fontWeight(index == selectedIndex ? .bold : .regular)
-                            .foregroundColor(
-                                index == selectedIndex ? .white :
-                                isEnabled ? Color.white.opacity(0.5) : Color.gray.opacity(0.3)
-                            )
-                            .frame(width: itemWidth, height: 40)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(index == selectedIndex ? Color.yellow : Color.clear)
-                            )
-                            .scaleEffect(index == selectedIndex ? 1.1 : 1.0)
-                            .animation(.easeInOut(duration: 0.15), value: selectedIndex)
-                    }
-                }
-                .offset(x: calculateOffset(geometry: geometry))
-                .gesture(
-                    isEnabled ? DragGesture()
-                        .updating($isDragging) { _, state, _ in
-                            state = true
-                        }
-                        .onChanged { value in
-                            dragOffset = value.translation.width
-                        }
-                        .onEnded { value in
-                            let totalOffset = value.translation.width
-                            let itemTotalWidth = itemWidth + itemSpacing
-                            let steps = Int(round(-totalOffset / itemTotalWidth))
-                            
-                            let newIndex = max(0, min(values.count - 1, selectedIndex + steps))
-                            if newIndex != selectedIndex {
-                                onValueChange(newIndex)
-                            }
-                            
-                            dragOffset = 0
-                        }
-                    : nil
-                )
-            }
-            .frame(height: 60)
-            
-            // Center Indicator
-            Rectangle()
-                .fill(Color.yellow)
-                .frame(width: 2, height: 20)
-                .offset(y: -10)
-        }
-        .opacity(isEnabled ? 1.0 : 0.5)
-    }
-    
-    private func calculateOffset(geometry: GeometryProxy) -> CGFloat {
-        let itemTotalWidth = itemWidth + itemSpacing
-        let centerX = geometry.size.width / 2
-        let selectedOffset = -CGFloat(selectedIndex) * itemTotalWidth
-        let centering = centerX - (itemWidth / 2)
-        
-        return centering + selectedOffset + (isDragging ? dragOffset : 0)
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/SettingButton.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/SettingButton.swift
@@ -67,9 +67,7 @@ struct SettingButton<SelectionType>: View {
                 }
                 
             } label: {
-                
                 Circle()
-                    
                     .frame(width: buttonWidth(for: type), height: buttonHeight(for: type))
                     .foregroundStyle(backgroundColor)
                     .overlay {
@@ -107,7 +105,7 @@ struct SettingButton<SelectionType>: View {
     }
 }
 
-struct CameraModeSelector: View {
+struct ShootingModeSelector: View {
     @Binding var selectedMode: ShootingModeType
     let isEnabled: Bool
     

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
@@ -182,7 +182,7 @@ struct PresetDetailView: View {
                 items: vm.getPictureStyleValues(),
                 config: .init(
                     spacing: 22,
-                    itemSize: .init(width: 50, height: 24)
+                    itemSize: .init(width: 100, height: 24)
                 )
             )
             

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
@@ -12,33 +12,31 @@ struct PresetDetailView: View {
     @State var vm: PresetDetailViewModel
     @State private var showDeleteAlert = false
     @State private var showUnsavedChangesAlert = false
-    @Environment(\.dismiss) private var dismiss
+    @Environment(\.dismiss) private var dismiss // TODO: - vm에서 nvrouter로 관리
     
     var body: some View {
         ZStack {
-            // Background
             Color.g12.ignoresSafeArea(.all)
             
             VStack(spacing: 0) {
                 // Preview Area
-                previewSection
+                previewView
                     .frame(height: 200)
                 
                 // Control Panel
                 VStack(spacing: 25) {
                     // Camera Mode Section
-                    cameraModeSection
+                    shootingModeView
                     
                     // Primary Settings
-                    primarySettingsSection
+                    primarySettingsView
                     
-                    // Value Slider (if active)
-                    if let activeSlider = vm.activeSlider {
-                        sliderSection(for: activeSlider)
+                    if let activePicker = vm.activePicker {
+                        pickerView(for: activePicker)
                     }
                     
                     // Secondary Settings
-                    secondarySettingsSection
+                    secondarySettingsSView
                 }
                 .padding(.horizontal, 20)
                 .padding(.top, 30)
@@ -61,7 +59,7 @@ struct PresetDetailView: View {
     }
     
     // MARK: - Preview Section
-    private var previewSection: some View {
+    private var previewView: some View {
         ZStack {
             // Sample Image (구름 사진)
             Image(systemName: "cloud.fill")
@@ -79,9 +77,9 @@ struct PresetDetailView: View {
         }
     }
     
-    // MARK: - Camera Mode Section
-    private var cameraModeSection: some View {
-        CameraModeSelector(
+    // Camera Mode Section
+    private var shootingModeView: some View {
+        ShootingModeSelector(
             selectedMode: Binding(
                 get: { vm.currentPreset.shootingMode },
                 set: { vm.changeCameraMode(to: $0) }
@@ -90,26 +88,26 @@ struct PresetDetailView: View {
         )
     }
     
-    // MARK: - Primary Settings Section
-    private var primarySettingsSection: some View {
+    // Primary Settings Section
+    private var primarySettingsView: some View {
         HStack {
-            // Aperture
+            // Aperture (조리개)
             SettingButton(
                 type: .aperture,
                 state: vm.getButtonState(for: .aperture),
                 value: vm.currentPreset.aperture ?? "Auto",
-                isSelected: vm.activeSlider == .aperture,
+                isSelected: vm.activePicker == .aperture,
                 action: {
                     handleSettingButtonTap(.aperture)
                 }
             )
             
-            // Shutter Speed
+            // Shutter Speed (셔터 스피드)
             SettingButton(
                 type: .shutterSpeed,
                 state: vm.getButtonState(for: .shutterSpeed),
                 value: vm.currentPreset.shutterSpeed ?? "Auto",
-                isSelected: vm.activeSlider == .shutterSpeed,
+                isSelected: vm.activePicker == .shutterSpeed,
                 action: {
                     handleSettingButtonTap(.shutterSpeed)
                 }
@@ -120,17 +118,18 @@ struct PresetDetailView: View {
                 type: .iso,
                 state: vm.getButtonState(for: .iso),
                 value: vm.currentPreset.iso ?? "Auto",
-                isSelected: vm.activeSlider == .iso,
+                isSelected: vm.activePicker == .iso,
                 action: {
                     handleSettingButtonTap(.iso)
                 }
             )
             
+            // Picture Style (픽쳐 스타일)
             SettingButton(
                 type: .pictureStyle,
                 state: vm.getButtonState(for: .pictureStyle),
                 value: vm.currentPreset.pictureStyle.rawValue,
-                isSelected: vm.activeSlider == .pictureStyle,
+                isSelected: vm.activePicker == .pictureStyle,
                 action: {
 
                     handleSettingButtonTap(.pictureStyle)
@@ -141,8 +140,7 @@ struct PresetDetailView: View {
         .frame(maxWidth: .infinity)
     }
     
-    // MARK: - Slider Section
-    private func sliderSection(for type: SettingType) -> some View {
+    private func pickerView(for type: SettingType) -> some View {
         Group {
             switch type {
             case .aperture:
@@ -228,65 +226,44 @@ struct PresetDetailView: View {
         .transition(.opacity)
     }
     
-    // MARK: - Secondary Settings Section
-    private var secondarySettingsSection: some View {
+    // Secondary Settings Section
+    private var secondarySettingsSView: some View {
         HStack(spacing: 30) {
-            // Exposure Compensation
             
+            // Tint Magenta Green (마젠타-그린)
             SettingButton(
                 type: .tintMagentaGreen,
                 state: vm.getButtonState(for: .tintMagentaGreen),
                 value: vm.currentPreset.tintMagentaGreen,
-                isSelected: vm.activeSlider == .tintMagentaGreen,
+                isSelected: vm.activePicker == .tintMagentaGreen,
                 action: {
                     handleSettingButtonTap(.tintMagentaGreen)
                 }
             )
             
+            // Exposure Compensation (노출 보정)
             SettingButton(  // plusminus.circle
                 type: .exposure,
                 state: vm.getButtonState(for: .exposure),
                 value: vm.currentPreset.exposureCompensation,
-                isSelected: vm.activeSlider == .exposure,
+                isSelected: vm.activePicker == .exposure,
                 action: {
                     handleSettingButtonTap(.exposure)
                 }
             )
             
+            // Color Temperature (색온도)
             SettingButton(  // thermometer.medium
                 type: .colorTemp,
                 state: vm.getButtonState(for: .colorTemp),
                 value: vm.currentPreset.colorTemperature,
-                isSelected: vm.activeSlider == .colorTemp,
+                isSelected: vm.activePicker == .colorTemp,
                 action: {
                     handleSettingButtonTap(.colorTemp)
                 }
             )
         }
     }
-    
-    // MARK: - Helper Methods
-//    private func buttonBackgroundColor(for type: SettingType) -> Color {
-//        switch vm.getButtonState(for: type) {
-//        case .active:
-//            return vm.activeSlider == type ? .white : Color.white.opacity(0.2)
-//        case .disabled:
-//            return Color.black.opacity(0.3)
-//        case .viewOnly:
-//            return Color.yellow.opacity(0.3)
-//        }
-//    }
-    
-//    private func buttonTextColor(for type: SettingType) -> Color {
-//        switch vm.getButtonState(for: type) {
-//        case .active:
-//            return vm.activeSlider == type ? .black : .white
-//        case .disabled:
-//            return Color.gray.opacity(0.5)
-//        case .viewOnly:
-//            return .black
-//        }
-//    }
     
     private func handleSettingButtonTap(_ type: SettingType) {
         guard vm.viewMode != .view else {
@@ -299,10 +276,10 @@ struct PresetDetailView: View {
             return
         }
         
-        if vm.activeSlider == type {
-            vm.activeSlider = nil
+        if vm.activePicker == type {
+            vm.activePicker = nil
         } else {
-            vm.activeSlider = type
+            vm.activePicker = type
         }
     }
     

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
@@ -146,29 +146,30 @@ struct PresetDetailView: View {
         Group {
             switch type {
             case .aperture:
-                
-                CustomWheelPickerView(
-                    selectedValue: $vm.currentPreset.aperture,
-                    items: vm.getApertureValues(),
-                    config: .init(
-                        spacing: 22,
-                        itemSize: .init(width: 50, height: 24)
+                if vm.currentPreset.shootingMode == .av {
+                    CustomWheelPickerView(
+                        selectedValue: $vm.currentPreset.aperture,
+                        items: vm.getApertureValues(),
+                        config: .init(
+                            spacing: 22,
+                            itemSize: .init(width: 50, height: 24)
+                        )
                     )
-                )
-
+                }
                 
                 
             case .shutterSpeed:
-                CustomWheelPickerView(
-                    selectedValue: $vm.currentPreset.shutterSpeed,
-                    items: vm.getShutterSpeedValues(),
-                    config: .init(
-                        spacing: 22,
-                        itemSize: .init(width: 50, height: 24)
+                if vm.currentPreset.shootingMode == .tv {
+                    CustomWheelPickerView(
+                        selectedValue: $vm.currentPreset.shutterSpeed,
+                        items: vm.getShutterSpeedValues(),
+                        config: .init(
+                            spacing: 22,
+                            itemSize: .init(width: 50, height: 24)
+                        )
                     )
-                )
-                
-                
+                    
+                }
             case .iso:
                 CustomWheelPickerView(
                     selectedValue: $vm.currentPreset.iso,
@@ -289,14 +290,15 @@ struct PresetDetailView: View {
     
     private func handleSettingButtonTap(_ type: SettingType) {
         guard vm.viewMode != .view else {
-            // 조회 모드에서는 편집 모드로 전환
             vm.switchToEditMode()
             return
         }
         
-        guard vm.isSettingEditable(type) else { return }
+        // 편집 불가능한 설정은 무시
+        guard vm.isSettingEditable(type) else {
+            return
+        }
         
-        // Toggle slider visibility
         if vm.activeSlider == type {
             vm.activeSlider = nil
         } else {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
@@ -139,90 +139,87 @@ struct PresetDetailView: View {
         .frame(maxWidth: .infinity)
     }
     
+    @ViewBuilder
     private func pickerView(for type: SettingType) -> some View {
-        Group {
-            switch type {
-            case .aperture:
-                if vm.currentPreset.shootingMode == .av {
-                    CustomWheelPickerView(
-                        selectedValue: $vm.currentPreset.aperture,
-                        items: vm.getApertureValues(),
-                        config: .init(
-                            spacing: 22,
-                            itemSize: .init(width: 50, height: 24)
-                        )
-                    )
-                }
-                
-                
-            case .shutterSpeed:
-                if vm.currentPreset.shootingMode == .tv {
-                    CustomWheelPickerView(
-                        selectedValue: $vm.currentPreset.shutterSpeed,
-                        items: vm.getShutterSpeedValues(),
-                        config: .init(
-                            spacing: 22,
-                            itemSize: .init(width: 50, height: 24)
-                        )
-                    )
-                    
-                }
-            case .iso:
+        switch type {
+        case .cameraMode:
+            EmptyView()
+            
+        case .aperture:
+            if vm.currentPreset.shootingMode == .av {
                 CustomWheelPickerView(
-                    selectedValue: $vm.currentPreset.iso,
-                    items: vm.getISOValues(),
+                    selectedValue: $vm.currentPreset.aperture,
+                    items: vm.getApertureValues(),
                     config: .init(
                         spacing: 22,
                         itemSize: .init(width: 50, height: 24)
                     )
                 )
-
-//            case .pictureStyle:
-//                CustomWheelPickerView(
-//                    selectedValue: $vm.currentPreset.pictureStyle,
-//                    items: vm.getPictureStyleValues(),
-//                    config: .init(
-//                        spacing: 22,
-//                        itemSize: .init(width: 50, height: 24)
-//                    )
-//                )
-                
-            case .tintMagentaGreen:
-                CustomWheelPickerView(
-                    selectedValue: $vm.currentPreset.tintMagentaGreen,
-                    items: vm.getTintMagentGreenValues(),
-                    config: .init(
-                        spacing: 22,
-                        itemSize: .init(width: 50, height: 24)
-                    )
-                )
-                
-            case .exposure:
-                CustomWheelPickerView(
-                    selectedValue: $vm.currentPreset.exposureCompensation,
-                    items: vm.getExposureCompensationValues(),
-                    config: .init(
-                        spacing: 22,
-                        itemSize: .init(width: 50, height: 24)
-                    )
-                )
-                
-//            case .colorTemp:
-//                CustomWheelPickerView(
-//                    selectedValue: $vm.currentPreset.colorTemperature,
-//                    items: vm.getColorTemperatureValues(),
-//                    config: .init(
-//                        spacing: 22,
-//                        itemSize: .init(width: 50, height: 24)
-//                    )
-//                )
-                
-            default:
-                EmptyView()
             }
+            
+            
+        case .shutterSpeed:
+            if vm.currentPreset.shootingMode == .tv {
+                CustomWheelPickerView(
+                    selectedValue: $vm.currentPreset.shutterSpeed,
+                    items: vm.getShutterSpeedValues(),
+                    config: .init(
+                        spacing: 22,
+                        itemSize: .init(width: 60, height: 24)
+                    )
+                )
+            }
+            
+        case .iso:
+            CustomWheelPickerView(
+                selectedValue: $vm.currentPreset.iso,
+                items: vm.getISOValues(),
+                config: .init(
+                    spacing: 22,
+                    itemSize: .init(width: 50, height: 24)
+                )
+            )
+            
+        case .pictureStyle:
+            NonOptionalWheelPickerView(
+                selectedValue: $vm.currentPreset.pictureStyle,
+                items: vm.getPictureStyleValues(),
+                config: .init(
+                    spacing: 22,
+                    itemSize: .init(width: 50, height: 24)
+                )
+            )
+            
+        case .tintMagentaGreen:
+            CustomWheelPickerView(
+                selectedValue: $vm.currentPreset.tintMagentaGreen,
+                items: vm.getTintMagentGreenValues(),
+                config: .init(
+                    spacing: 22,
+                    itemSize: .init(width: 50, height: 24)
+                )
+            )
+            
+        case .exposure:
+            CustomWheelPickerView(
+                selectedValue: $vm.currentPreset.exposureCompensation,
+                items: vm.getExposureCompensationValues(),
+                config: .init(
+                    spacing: 22,
+                    itemSize: .init(width: 60, height: 24)
+                )
+            )
+            
+        case .colorTemp:
+            CustomWheelPickerView(
+                selectedValue: $vm.currentPreset.colorTemperature,
+                items: vm.getColorTemperatureValues(),
+                config: .init(
+                    spacing: 22,
+                    itemSize: .init(width: 50, height: 24)
+                )
+            )
         }
-        .frame(height: 80)
-        .transition(.opacity)
     }
     
     // Secondary Settings Section

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
@@ -19,24 +19,20 @@ struct PresetDetailView: View {
             Color.g12.ignoresSafeArea(.all)
             
             VStack(spacing: 0) {
-                // Preview Area
-                previewView
+                previewView()
                     .frame(height: 200)
                 
-                // Control Panel
                 VStack(spacing: 25) {
-                    // Camera Mode Section
-                    shootingModeView
+                    shootingModeView()
                     
                     // Primary Settings
-                    primarySettingsView
+                    primarySettingsView()
                     
                     if let activePicker = vm.activePicker {
                         pickerView(for: activePicker)
                     }
                     
-                    // Secondary Settings
-                    secondarySettingsSView
+                    secondarySettingsSView()
                 }
                 .padding(.horizontal, 20)
                 .padding(.top, 30)
@@ -46,7 +42,7 @@ struct PresetDetailView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            toolbarContent
+            toolbarContent()
         }
         .alert("변경사항 저장", isPresented: $showUnsavedChangesAlert) {
             Button("저장하지 않고 나가기", role: .destructive) {
@@ -58,8 +54,8 @@ struct PresetDetailView: View {
         }
     }
     
-    // MARK: - Preview Section
-    private var previewView: some View {
+    // Preview Section
+    private func previewView() -> some View {
         ZStack {
             // Sample Image (구름 사진)
             Image(systemName: "cloud.fill")
@@ -78,7 +74,7 @@ struct PresetDetailView: View {
     }
     
     // Camera Mode Section
-    private var shootingModeView: some View {
+    private func shootingModeView() -> some View {
         ShootingModeSelector(
             selectedMode: Binding(
                 get: { vm.currentPreset.shootingMode },
@@ -89,7 +85,7 @@ struct PresetDetailView: View {
     }
     
     // Primary Settings Section
-    private var primarySettingsView: some View {
+    private func primarySettingsView() -> some View {
         HStack {
             // Aperture (조리개)
             SettingButton(
@@ -223,7 +219,7 @@ struct PresetDetailView: View {
     }
     
     // Secondary Settings Section
-    private var secondarySettingsSView: some View {
+    private func secondarySettingsSView() -> some View {
         HStack(spacing: 30) {
             
             // Tint Magenta Green (마젠타-그린)
@@ -261,7 +257,7 @@ struct PresetDetailView: View {
         }
     }
     
-    private func handleSettingButtonTap(_ type: SettingType) {
+    private func handleSettingButtonTap(_ type: SettingType){
         guard vm.viewMode != .view else {
             vm.switchToEditMode()
             return
@@ -281,7 +277,7 @@ struct PresetDetailView: View {
     
     // Toolbar
     @ToolbarContentBuilder
-    private var toolbarContent: some ToolbarContent {
+    private func toolbarContent() -> some ToolbarContent {
         ToolbarItem(placement: .navigationBarLeading) {
             Button("취소") {
                 if vm.viewMode == .create {
@@ -321,7 +317,6 @@ struct PresetDetailView: View {
     }
 }
 
-// MARK: - Preview
 #Preview("View Mode") {
     PresetDetailView(vm: .init(container: .stub, mode: .view, preset: .stub1))
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
@@ -22,7 +22,7 @@ struct PresetDetailView: View {
             VStack(spacing: 0) {
                 // Preview Area
                 previewSection
-                    .frame(height: UIScreen.main.bounds.height * 0.35)
+                    .frame(height: 200)
                 
                 // Control Panel
                 VStack(spacing: 25) {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
@@ -95,7 +95,7 @@ struct PresetDetailView: View {
             SettingButton(
                 type: .aperture,
                 state: vm.getButtonState(for: .aperture),
-                value: vm.currentPreset.aperture ?? "Auto",
+                value: vm.currentPreset.displayAperture,
                 isSelected: vm.activePicker == .aperture,
                 action: {
                     handleSettingButtonTap(.aperture)
@@ -106,7 +106,7 @@ struct PresetDetailView: View {
             SettingButton(
                 type: .shutterSpeed,
                 state: vm.getButtonState(for: .shutterSpeed),
-                value: vm.currentPreset.shutterSpeed ?? "Auto",
+                value: vm.currentPreset.displayShutterSpeed,
                 isSelected: vm.activePicker == .shutterSpeed,
                 action: {
                     handleSettingButtonTap(.shutterSpeed)
@@ -117,7 +117,7 @@ struct PresetDetailView: View {
             SettingButton(
                 type: .iso,
                 state: vm.getButtonState(for: .iso),
-                value: vm.currentPreset.iso ?? "Auto",
+                value: vm.currentPreset.displayISO,
                 isSelected: vm.activePicker == .iso,
                 action: {
                     handleSettingButtonTap(.iso)
@@ -131,7 +131,6 @@ struct PresetDetailView: View {
                 value: vm.currentPreset.pictureStyle.rawValue,
                 isSelected: vm.activePicker == .pictureStyle,
                 action: {
-
                     handleSettingButtonTap(.pictureStyle)
                 }
             )
@@ -234,7 +233,7 @@ struct PresetDetailView: View {
             SettingButton(
                 type: .tintMagentaGreen,
                 state: vm.getButtonState(for: .tintMagentaGreen),
-                value: vm.currentPreset.tintMagentaGreen,
+                value: vm.currentPreset.displayTintMagentaGreen,
                 isSelected: vm.activePicker == .tintMagentaGreen,
                 action: {
                     handleSettingButtonTap(.tintMagentaGreen)
@@ -242,10 +241,10 @@ struct PresetDetailView: View {
             )
             
             // Exposure Compensation (노출 보정)
-            SettingButton(  // plusminus.circle
+            SettingButton(
                 type: .exposure,
                 state: vm.getButtonState(for: .exposure),
-                value: vm.currentPreset.exposureCompensation,
+                value: vm.currentPreset.displayExposureCompensation,
                 isSelected: vm.activePicker == .exposure,
                 action: {
                     handleSettingButtonTap(.exposure)
@@ -253,10 +252,10 @@ struct PresetDetailView: View {
             )
             
             // Color Temperature (색온도)
-            SettingButton(  // thermometer.medium
+            SettingButton(
                 type: .colorTemp,
                 state: vm.getButtonState(for: .colorTemp),
-                value: vm.currentPreset.colorTemperature,
+                value: vm.currentPreset.displayColorTemperature,
                 isSelected: vm.activePicker == .colorTemp,
                 action: {
                     handleSettingButtonTap(.colorTemp)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
@@ -14,65 +14,147 @@ struct PresetView: View {
     @State var vm: PresetViewModel
     @State private var showToast: Bool = false
     @State private var toastMessage: String = ""
+    @Namespace private var namespace
     
     var body: some View {
-        ZStack(alignment: .bottom) {
-            presetGridScrollView()
-
-            Group {
-                if vm.isPresetEditMode {
-                    deleteButton()
-                } else {
-                    HStack {
-                        Spacer()
-                        addButton()
+//        NavigationStack {
+            ZStack(alignment: .bottom) {
+                // 메인 컨텐츠
+                mainContent
+                
+                // 하단 버튼
+                Group {
+                    if vm.isPresetEditMode {
+                        deleteButton()
+                    } else {
+                        HStack {
+                            Spacer()
+                            addButton()
+                        }
                     }
                 }
+                .padding(.bottom, 24)
+                .padding(.horizontal)
             }
-            .padding(.bottom, 24)
-        }
-        .environment(vm)
+            .navigationTitle("프리셋")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    viewModeMenu
+                }
+            }
+            .environment(vm)
+            .onAppear {
+                vm.loadPresets()
+            }
+//        }
     }
     
-    private func presetGridScrollView() -> some View {
+    // MARK: - Main Content
+    @ViewBuilder
+    private var mainContent: some View {
         ScrollView {
-            presetGridView()
-                .padding(.top, 3)
-                .padding(.horizontal, 2)
+            if vm.viewMode == .grid {
+                gridView
+            } else {
+                listView
+            }
         }
         .scrollIndicators(.hidden)
+        .animation(.easeInOut(duration: 0.3), value: vm.viewMode)
     }
     
-    private func presetGridView() -> some View {
-        let columns = [
-            GridItem(.flexible(), spacing: 10),
-            GridItem(.flexible(), spacing: 10)
-        ]
-        
-        return LazyVGrid(columns: columns, spacing: 10) {
-            //TODO: Preset 데이터 연결 필요
+    // MARK: - Grid View
+    private var gridView: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.flexible(), spacing: 10),
+                GridItem(.flexible(), spacing: 10)
+            ],
+            spacing: 10
+        ) {
+            ForEach(vm.presets) { preset in
+                PresetGridItem(
+                    preset: preset,
+                    isSelected: vm.selectedPresets.contains(preset.id),
+                    isEditMode: vm.isPresetEditMode,
+                    onTap: {
+                        handlePresetTap(preset)
+                    },
+                    onActionTap: {
+                        Task {
+                            await vm.setCurrentPreset(preset)
+                            showToastMessage("\(preset.name) 적용됨")
+                        }
+                    }
+                )
+                .matchedGeometryEffect(id: preset.id, in: namespace)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+    }
+    
+    // MARK: - List View
+    private var listView: some View {
+        LazyVStack(spacing: 10) {
+            ForEach(vm.presets) { preset in
+                PresetListItem(
+                    preset: preset,
+                    isSelected: vm.selectedPresets.contains(preset.id),
+                    isEditMode: vm.isPresetEditMode,
+                    onTap: {
+                        handlePresetTap(preset)
+                    },
+                    onActionTap: {
+                        Task {
+                            await vm.setCurrentPreset(preset)
+                            showToastMessage("\(preset.name) 적용됨")
+                        }
+                    }
+                )
+                .matchedGeometryEffect(id: preset.id, in: namespace)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+    }
+    
+    // MARK: - View Mode Menu
+    private var viewModeMenu: some View {
+        Menu {
+            Button {
+                vm.setViewMode(.list)
+            } label: {
+                Label("리스트 보기", systemImage: "list.bullet")
+            }
+            
+            Button {
+                vm.setViewMode(.grid)
+            } label: {
+                Label("그리드 보기", systemImage: "square.grid.2x2")
+            }
+        } label: {
+            Image(systemName: vm.viewMode == .grid ? "square.grid.2x2" : "list.bullet")
+                .font(.system(size: 18))
+                .foregroundColor(.primary)
         }
     }
-
+    
+    // MARK: - Buttons
     private func addButton() -> some View {
         Button {
             vm.send(action: .goToPresetDetail(.create, nil))
         } label: {
-            if #available(iOS 26.0, *) {
-                Image(systemName: "plus")
-                    .font(.system(size: 24, weight: .semibold))
-                    .foregroundStyle(.black)
-                    .frame(width: 48, height: 48)
-            } else {
-                Image(systemName: "plus")
-                    .font(.system(size: 24, weight: .semibold))
-                    .foregroundStyle(.black)
-                    .frame(width: 48, height: 48)
-                    .background(Circle().fill(.gray))
-            }
+            Image(systemName: "plus")
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 56, height: 56)
+                .background(Circle().fill(Color.blue))
+                .shadow(radius: 4, y: 2)
         }
     }
-
+    
     private func deleteButton() -> some View {
         Button {
             vm.deleteSelectedPresets()
@@ -90,6 +172,48 @@ struct PresetView: View {
             .cornerRadius(12)
         }
         .disabled(vm.selectedPresets.isEmpty)
+        .padding(.horizontal)
+    }
+    
+    // MARK: - Helper Methods
+    private func handlePresetTap(_ preset: Preset) {
+        if vm.isPresetEditMode {
+            vm.toggleSelection(for: preset)
+        } else {
+            vm.send(action: .goToPresetDetail(.edit, preset))
+        }
+    }
+    
+    private func showToastMessage(_ message: String) {
+        toastMessage = message
+        withAnimation {
+            showToast = true
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            withAnimation {
+                showToast = false
+            }
+        }
+    }
+}
+
+// MARK: - Toast View
+extension PresetView {
+    @ViewBuilder
+    private var toastView: some View {
+        if showToast {
+            Text(toastMessage)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.white)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(
+                    Capsule()
+                        .fill(Color.black.opacity(0.8))
+                )
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
     }
 }
 

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
@@ -44,7 +44,7 @@ struct PresetView: View {
         }
     }
     
-    // MARK: - Main Content
+    // Main Content
     @ViewBuilder
     private var mainContent: some View {
         ScrollView {
@@ -85,7 +85,6 @@ struct PresetView: View {
                 .matchedGeometryEffect(id: preset.id, in: namespace)
             }
         }
-        .padding(.horizontal, 16)
         .padding(.top, 16)
     }
     
@@ -109,7 +108,6 @@ struct PresetView: View {
                 .matchedGeometryEffect(id: preset.id, in: namespace)
             }
         }
-        .padding(.horizontal, 16)
         .padding(.top, 16)
     }
     

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
@@ -17,25 +17,23 @@ struct PresetView: View {
     
     var body: some View {
         ZStack(alignment: .bottom) {
-            mainContent
+            mainView
 
             Group {
                 if vm.isPresetEditMode {
-                    deleteButton()
+                    deleteButtonView()
                 } else {
                     HStack {
                         Spacer()
-                        addButton()
+                        addButtonView()
                     }
                 }
             }
             .padding(.bottom, 24)
         }
-        .navigationTitle("프리셋")
-        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                viewModeMenu
+                viewModeMenuView
             }
         }
         .environment(vm)
@@ -44,9 +42,8 @@ struct PresetView: View {
         }
     }
     
-    // Main Content
     @ViewBuilder
-    private var mainContent: some View {
+    private var mainView: some View {
         ScrollView {
             if vm.viewMode == .grid {
                 gridView
@@ -58,7 +55,6 @@ struct PresetView: View {
         .animation(.easeInOut(duration: 0.3), value: vm.viewMode)
     }
     
-    // Grid View
     private var gridView: some View {
         LazyVGrid(
             columns: [
@@ -111,19 +107,21 @@ struct PresetView: View {
         .padding(.top, 16)
     }
     
-    // View Mode Menu
-    private var viewModeMenu: some View {
+    private var viewModeMenuView: some View {
         Menu {
-            Button {
-                vm.setViewMode(.list)
-            } label: {
-                Label("리스트 보기", systemImage: "list.bullet")
-            }
-            
-            Button {
-                vm.setViewMode(.grid)
-            } label: {
-                Label("그리드 보기", systemImage: "square.grid.2x2")
+            switch vm.viewMode {
+            case .grid:
+                Button {
+                    vm.setViewMode(.list)
+                } label: {
+                    Label("리스트 보기", systemImage: "list.bullet")
+                }
+            case .list:
+                Button {
+                    vm.setViewMode(.grid)
+                } label: {
+                    Label("그리드 보기", systemImage: "square.grid.2x2")
+                }
             }
         } label: {
             Image(systemName: vm.viewMode == .grid ? "square.grid.2x2" : "list.bullet")
@@ -133,20 +131,19 @@ struct PresetView: View {
     }
     
     // Buttons
-    private func addButton() -> some View {
+    private func addButtonView() -> some View {
         Button {
             vm.send(action: .goToPresetDetail(.create, nil))
         } label: {
             Image(systemName: "plus")
                 .font(.system(size: 24, weight: .semibold))
-                .foregroundStyle(.white)
-                .frame(width: 56, height: 56)
-                .background(Circle().fill(Color.blue))
-                .shadow(radius: 4, y: 2)
+                .foregroundStyle(Color.g0)
+                .frame(width: 50, height: 50)
+                .background(Circle().fill(Color.g0))
         }
     }
     
-    private func deleteButton() -> some View {
+    private func deleteButtonView() -> some View {
         Button {
             vm.deleteSelectedPresets()
             vm.isPresetEditMode = false

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
@@ -30,7 +30,6 @@ struct PresetView: View {
                 }
             }
             .padding(.bottom, 24)
-            .padding(.horizontal)
         }
         .navigationTitle("프리셋")
         .navigationBarTitleDisplayMode(.inline)
@@ -59,7 +58,7 @@ struct PresetView: View {
         .animation(.easeInOut(duration: 0.3), value: vm.viewMode)
     }
     
-    // MARK: - Grid View
+    // Grid View
     private var gridView: some View {
         LazyVGrid(
             columns: [
@@ -114,7 +113,7 @@ struct PresetView: View {
         .padding(.top, 16)
     }
     
-    // MARK: - View Mode Menu
+    // View Mode Menu
     private var viewModeMenu: some View {
         Menu {
             Button {
@@ -135,7 +134,7 @@ struct PresetView: View {
         }
     }
     
-    // MARK: - Buttons
+    // Buttons
     private func addButton() -> some View {
         Button {
             vm.send(action: .goToPresetDetail(.create, nil))
@@ -169,7 +168,7 @@ struct PresetView: View {
         .padding(.horizontal)
     }
     
-    // MARK: - Helper Methods
+    // Helper Methods
     private func handlePresetTap(_ preset: Preset) {
         if vm.isPresetEditMode {
             vm.toggleSelection(for: preset)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
@@ -137,7 +137,7 @@ struct PresetView: View {
         } label: {
             Image(systemName: "plus")
                 .font(.system(size: 24, weight: .semibold))
-                .foregroundStyle(Color.g0)
+                .foregroundStyle(Color.g12)
                 .frame(width: 50, height: 50)
                 .background(Circle().fill(Color.g0))
         }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
@@ -10,44 +10,39 @@ import SwiftData
 
 struct PresetView: View {
     @EnvironmentObject private var container: DIContainer
-    
     @State var vm: PresetViewModel
     @State private var showToast: Bool = false
     @State private var toastMessage: String = ""
     @Namespace private var namespace
     
     var body: some View {
-//        NavigationStack {
-            ZStack(alignment: .bottom) {
-                // 메인 컨텐츠
-                mainContent
-                
-                // 하단 버튼
-                Group {
-                    if vm.isPresetEditMode {
-                        deleteButton()
-                    } else {
-                        HStack {
-                            Spacer()
-                            addButton()
-                        }
+        ZStack(alignment: .bottom) {
+            mainContent
+
+            Group {
+                if vm.isPresetEditMode {
+                    deleteButton()
+                } else {
+                    HStack {
+                        Spacer()
+                        addButton()
                     }
                 }
-                .padding(.bottom, 24)
-                .padding(.horizontal)
             }
-            .navigationTitle("프리셋")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    viewModeMenu
-                }
+            .padding(.bottom, 24)
+            .padding(.horizontal)
+        }
+        .navigationTitle("프리셋")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                viewModeMenu
             }
-            .environment(vm)
-            .onAppear {
-                vm.loadPresets()
-            }
-//        }
+        }
+        .environment(vm)
+        .onAppear {
+            vm.loadPresets()
+        }
     }
     
     // MARK: - Main Content
@@ -95,7 +90,6 @@ struct PresetView: View {
         .padding(.top, 16)
     }
     
-    // MARK: - List View
     private var listView: some View {
         LazyVStack(spacing: 10) {
             ForEach(vm.presets) { preset in
@@ -198,7 +192,7 @@ struct PresetView: View {
     }
 }
 
-// MARK: - Toast View
+// Toast View
 extension PresetView {
     @ViewBuilder
     private var toastView: some View {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
@@ -64,7 +64,7 @@ struct PresetView: View {
             spacing: 10
         ) {
             ForEach(vm.presets) { preset in
-                PresetGridItem(
+                PresetGridItemView(
                     preset: preset,
                     isSelected: vm.selectedPresets.contains(preset.id),
                     isEditMode: vm.isPresetEditMode,
@@ -87,7 +87,7 @@ struct PresetView: View {
     private var listView: some View {
         LazyVStack(spacing: 10) {
             ForEach(vm.presets) { preset in
-                PresetListItem(
+                PresetListItemView(
                     preset: preset,
                     isSelected: vm.selectedPresets.contains(preset.id),
                     isEditMode: vm.isPresetEditMode,

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
@@ -22,7 +22,7 @@ class PresetDetailViewModel {
     var isLoading: Bool = false
     var errorMessage: String?
     var showCameraModeSelector: Bool = false
-    var activeSlider: SettingType?
+    var activePicker: SettingType?
     
     private var originalPreset: Preset?
     
@@ -51,7 +51,7 @@ class PresetDetailViewModel {
     
     func switchToViewMode() {
         viewMode = .view
-        activeSlider = nil
+        activePicker = nil
         showCameraModeSelector = false
     }
     
@@ -66,7 +66,7 @@ class PresetDetailViewModel {
         guard currentPreset.shootingMode != mode else { return }
         
         currentPreset.shootingMode = mode
-        activeSlider = nil
+        activePicker = nil
         
         // Auto 처리를 위해 적절한 nil 설정
         switch mode {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
@@ -220,8 +220,8 @@ class PresetDetailViewModel {
         return CameraConstants.shutterSpeedValues
     }
     
-    func getPictureStyleValues() -> [String] {
-        return CameraConstants.pictureStyleValues
+    func getPictureStyleValues() -> [PictureStyleType] {
+        return PictureStyleType.allCases
     }
     
     func getTintMagentGreenValues() -> [Int] {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
@@ -150,16 +150,15 @@ class PresetDetailViewModel {
     func savePreset() async throws {
         isLoading = true
         defer { isLoading = false }
-        
-        // 1. updatedAt 갱신
-        currentPreset.updatedAt = Date()
-        
-        // 2. PresetManager 가져오기
+
         let presetManager = container.managers.presetManager
         
-        // 3. viewMode에 따라 create/update 분기
         do {
+            currentPreset.updatedAt = Date()
+            
             switch viewMode {
+                
+                
             case .create:
                 // 새 프리셋 생성
                 try presetManager.createPreset(currentPreset)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
@@ -61,7 +61,7 @@ class PresetDetailViewModel {
         originalPreset = nil
     }
     
-    // MARK: - Camera Mode Management
+    // Camera Mode Management
     func changeCameraMode(to mode: ShootingModeType) {
         guard currentPreset.shootingMode != mode else { return }
         
@@ -91,7 +91,7 @@ class PresetDetailViewModel {
         }
     }
 
-    // MARK: - Button State
+    // Button State
     func getButtonState(for type: SettingType) -> ButtonState {
         // 조회 모드에서는 모든 버튼이 viewOnly
         if viewMode == .view {
@@ -118,7 +118,7 @@ class PresetDetailViewModel {
         return getButtonState(for: type) == .active
     }
     
-    // MARK: - Value Updates
+    // Value Updates
     func updateAperture(_ value: String) {
         guard isSettingEditable(.aperture) else { return }
         currentPreset.aperture = value
@@ -146,7 +146,7 @@ class PresetDetailViewModel {
         return "\(value)K"
     }
     
-    // MARK: - Data Persistence
+    // Data Persistence
     func savePreset() async throws {
         isLoading = true
         defer { isLoading = false }
@@ -207,7 +207,7 @@ class PresetDetailViewModel {
         lhs.colorTemperature == rhs.colorTemperature
     }
     
-    // MARK: - Get Setting Values
+    // Get Setting Values
     func getISOValues() -> [String] {
         return CameraConstants.isoValues
     }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
@@ -66,6 +66,7 @@ class PresetDetailViewModel {
         guard currentPreset.shootingMode != mode else { return }
         
         currentPreset.shootingMode = mode
+        activeSlider = nil
         
         // Auto 처리를 위해 적절한 nil 설정
         switch mode {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
@@ -61,7 +61,7 @@ class PresetDetailViewModel {
         originalPreset = nil
     }
     
-    // Camera Mode Management
+    // MARK: - Camera Mode Management
     func changeCameraMode(to mode: ShootingModeType) {
         guard currentPreset.shootingMode != mode else { return }
         
@@ -91,9 +91,9 @@ class PresetDetailViewModel {
         }
     }
 
+    // MARK: - Button State
     func getButtonState(for type: SettingType) -> ButtonState {
         // 조회 모드에서는 모든 버튼이 viewOnly
-        // TODO: 값에 따라 노란색 / 비활성화
         if viewMode == .view {
             return .viewOnly
         }
@@ -118,7 +118,7 @@ class PresetDetailViewModel {
         return getButtonState(for: type) == .active
     }
     
-    // Value Updates
+    // MARK: - Value Updates
     func updateAperture(_ value: String) {
         guard isSettingEditable(.aperture) else { return }
         currentPreset.aperture = value
@@ -142,60 +142,45 @@ class PresetDetailViewModel {
         currentPreset.colorTemperature = value
     }
     
-    // Formatting Values
-//    func formatAperture(_ value: String?) -> String {
-//        guard let value = value else { return "Auto" }
-//        // 소수점 처리
-//        if value.truncatingRemainder(dividingBy: 1) == 0 {
-//            return "f/\(Int(value))"
-//        } else {
-//            return "f/\(String(format: "%.1f", value))"
-//        }
-//    }
-    
-//    func formatShutterSpeed(_ value: Double?) -> String {
-//        guard let value = value else { return "Auto" }
-//        
-//        if value < 1 {
-//            let denominator = Int(1/value)
-//            return "1/\(denominator)"
-//        } else if value.truncatingRemainder(dividingBy: 1) == 0 {
-//            return "\(Int(value))\""
-//        } else {
-//            return "\(String(format: "%.1f", value))\""
-//        }
-//    }
-    
-//    func formatISO(_ value: Int) -> String {
-//        return "\(value)"
-//    }
-    
-//    func formatExposureCompensation(_ value: Double) -> String {
-//        if value > 0 {
-//            return "+\(String(format: "%.1f", value))"
-//        } else if value < 0 {
-//            return String(format: "%.1f", value)
-//        } else {
-//            return "+0.0"
-//        }
-//    }
-    
     func formatColorTemperature(_ value: Int) -> String {
         return "\(value)K"
     }
     
-    // Data Persistence
+    // MARK: - Data Persistence
     func savePreset() async throws {
         isLoading = true
         defer { isLoading = false }
         
-        // 실제 저장 로직 구현
+        // 1. updatedAt 갱신
         currentPreset.updatedAt = Date()
         
-        // API 호출 또는 로컬 저장 로직
-        try await Task.sleep(nanoseconds: 500_000_000) // 시뮬레이션
+        // 2. PresetManager 가져오기
+        let presetManager = container.managers.presetManager
         
-        switchToViewMode()
+        // 3. viewMode에 따라 create/update 분기
+        do {
+            switch viewMode {
+            case .create:
+                // 새 프리셋 생성
+                try presetManager.createPreset(currentPreset)
+                
+            case .edit:
+                // 기존 프리셋 업데이트
+                try presetManager.updatePreset(currentPreset)
+                
+            case .view:
+                // 조회 모드에서는 저장 불가 (도달하지 않음)
+                break
+            }
+            
+            // 4. 성공 시 View 모드로 전환
+            switchToViewMode()
+            
+        } catch {
+            // 에러 처리
+            errorMessage = "저장에 실패했습니다: \(error.localizedDescription)"
+            throw error
+        }
     }
     
     func cancelEditing() {
@@ -222,7 +207,7 @@ class PresetDetailViewModel {
         lhs.colorTemperature == rhs.colorTemperature
     }
     
-    // 임시 세팅값 가져오기
+    // MARK: - Get Setting Values
     func getISOValues() -> [String] {
         return CameraConstants.isoValues
     }
@@ -244,88 +229,10 @@ class PresetDetailViewModel {
     }
     
     func getExposureCompensationValues() -> [String] {
-        return CameraConstants.exposureCompensationRange
-            .map(\.description)
+        return CameraConstants.exposureCompensationValues
     }
     
-    func getColorTemperatureValues() -> [String] {
-        return CameraConstants.colorTemperatureRange
-            .map(\.description)
+    func getColorTemperatureValues() -> [Int] {
+        return CameraConstants.colorTemperatureValues
     }
 }
-//MARK: - Navigation
-//extension PresetDetailViewModel {
-//    func send(action: Action) {
-//        switch action {
-//        case .popToPresetView:
-//            container.navigationRouter.pop()
-//        }
-//    }
-//}
-
-// MARK: - PresetManager CRUD
-//extension PresetDetailViewModel {
-//    
-//    /// Preset 생성
-//    func createPreset() {
-//        do {
-//            // updatedAt을 현재 시간으로 설정
-//            newPreset?.updatedAt = Date()
-//            
-//            if let newPreset = newPreset {
-//                try presetManager.createPreset(newPreset)
-//            }
-//            
-//            
-//            error = nil
-//            
-//            // 생성 후 목록으로 돌아가기
-//            send(action: .popToPresetView)
-//        } catch {
-////            handleError(error)
-//        }
-//    }
-//    
-//    /// Preset 업데이트
-//    func updatePreset() {
-//        do {
-//            // updatedAt을 현재 시간으로 설정
-//            guard let selectedPreset else { return }
-//            selectedPreset.updatedAt = Date()
-//            
-//            try presetManager.updatePreset(selectedPreset)
-//            error = nil
-//            
-//            // 업데이트 후 목록으로 돌아가기
-//            send(action: .popToPresetView)
-//        } catch {
-////            handleError(error)
-//        }
-//    }
-//    
-//    /// Preset 삭제
-//    func deletePreset() {
-//        do {
-//            guard let selectedPreset else { return }
-//            try presetManager.deletePreset(selectedPreset)
-//            error = nil
-//            
-//            // 삭제 후 목록으로 돌아가기
-//            send(action: .popToPresetView)
-//        } catch {
-////            handleError(error)
-//        }
-//    }
-//    
-//    /// 특정 Preset 조회 (필요 시)
-//    func loadPreset(by id: UUID) {
-//        do {
-//            if let preset = try presetManager.fetchPreset(by: id) {
-//                selectedPreset = preset
-//                error = nil
-//            }
-//        } catch {
-////            handleError(error)
-//        }
-//    }
-//}

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetViewModel.swift
@@ -25,6 +25,10 @@ final class PresetViewModel {
     var presets: [Preset] = []
     var selectedPresets: Set<UUID> = []
     var error: PresetError?
+    
+    // 뷰 모드 관련 추가 속성
+    var viewMode: PresetViewMode = .list
+    var isViewModeMenuPresented: Bool = false
 
     enum Action {
         case goToPresetDetail(ViewMode, Preset?)
@@ -42,9 +46,28 @@ final class PresetViewModel {
         self.shootingControlService = container.services.shootingControlService
         self.shootingSettingsService = container.services.shootingSettingsService
         self.presetManager = container.managers.presetManager
+        
+        // 초기 데이터 로드
+        loadPresets()
     }
 }
 
+// MARK: - View Mode Methods
+extension PresetViewModel {
+    func toggleViewMode() {
+        withAnimation(.easeInOut(duration: 0.3)) {
+            viewMode = viewMode == .grid ? .list : .grid
+        }
+    }
+    
+    func setViewMode(_ mode: PresetViewMode) {
+        withAnimation(.easeInOut(duration: 0.3)) {
+            viewMode = mode
+        }
+    }
+}
+
+// MARK: - Actions
 extension PresetViewModel {
     
     func send(action: PresetAction) {
@@ -147,6 +170,7 @@ extension PresetViewModel {
     }
 }
 
+// MARK: - Data Loading
 extension PresetViewModel {
     func loadPresets() {
         do {
@@ -158,6 +182,7 @@ extension PresetViewModel {
     }
 }
 
+// MARK: - API Methods
 extension PresetViewModel: PresetErrorHandleable {
     private func ignoreShootingMode(action: String) async throws {
         let request = ShootingControl.IgnoreShootingModeRequest(action: action)


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #80 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- PresetDetailView에서 Preset을 CoreData에 저장
- PresetView에서 저장된 Preset 조회
- PresetViewItem의 Grid <-> List 전환
---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

| Preset 생성 후 조회 | 리스트 <-> 그리드 전환 | Trishot에서 Preset 설정 |
|----------|----------|----------|
| ![Simulator Screen Recording - iPhone 16 - 2025-11-06 at 04 38 37](https://github.com/user-attachments/assets/b2239c6f-3734-4922-a902-f07d994f0315) | ![Simulator Screen Recording - iPhone 16 - 2025-11-06 at 04 43 37](https://github.com/user-attachments/assets/57a292e0-1b05-460c-988d-68a7d387cca9) | ![Simulator Screen Recording - iPhone 16 - 2025-11-06 at 04 44 38](https://github.com/user-attachments/assets/bf7d973b-3406-498d-a0df-48b808f73b91) |

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 16, iOS 18 환경에서 정상 동작
- [x] Trishot 화면에서도 저장된 Preset 정상 조회 및 변경 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- PresetView에 Navigation 입혀야 합니다...



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 프리셋 목록을 그리드/리스트로 전환 가능한 뷰 모드 추가
  * 프리셋 아이템용 그리드/리스트 전용 컴포넌트(PresetGridItemView, PresetListItemView) 추가
  * 간편한 알림 토스트(UI)로 프리셋 작업 피드백 표시

* **개선 사항**
  * 상세 화면 UI 재구성 및 피커 기반 설정 조작으로 편의성 향상
  * 조리개/셔터/ISO/노출/화이트밸런스 등 표시 포맷 개선
  * 프리셋 로드·저장 흐름 개선 및 편집/선택 상태 표시 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->