### PR TITLE
Test: #76 LiveStream 프레임 끊기는 오류 해결

### DIFF
--- a/HonestHouse/HonestHouse/Sources/Core/Managers/PresetManager.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Managers/PresetManager.swift
@@ -124,8 +124,7 @@ final class PresetManager: PresetManagerType {
 
         try saveContext()
         
-        Logger.info("✅ Preset created successfully: \(preset.name) (id: \(preset.id))", category: .coreData)
-//        logPresetDetails(preset)
+        Logger.info("Preset created successfully: \(preset.name) (id: \(preset.id))", category: .coreData)
     }
     
     /// Preset 업데이트
@@ -144,7 +143,7 @@ final class PresetManager: PresetManagerType {
         
         try saveContext()
         
-        Logger.info("✅ Preset updated successfully: \(preset.name) (id: \(preset.id))", category: .coreData)
+        Logger.info("Preset updated successfully: \(preset.name) (id: \(preset.id))", category: .coreData)
 //        logPresetDetails(preset)
     }
     
@@ -169,7 +168,7 @@ final class PresetManager: PresetManagerType {
         
         try saveContext()
         
-        Logger.info("✅ Preset deleted successfully (id: \(id))", category: .coreData)
+        Logger.info("Preset deleted successfully (id: \(id))", category: .coreData)
     }
     
     /// Preset → PresetEntity 변환 (업데이트용)
@@ -219,9 +218,9 @@ final class PresetManager: PresetManagerType {
         if viewContext.hasChanges {
             do {
                 try viewContext.save()
-                Logger.debug("💾 CoreData context saved successfully", category: .coreData)
+                Logger.debug("CoreData context saved successfully", category: .coreData)
             } catch {
-                Logger.error("❌ Failed to save CoreData context: \(error.localizedDescription)", category: .coreData)
+                Logger.error("Failed to save CoreData context: \(error.localizedDescription)", category: .coreData)
                 throw PresetManagerError.saveFailed(error)
             }
         } else {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Live/ChunkedStreamParser.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Live/ChunkedStreamParser.swift
@@ -49,7 +49,6 @@ actor ChunkedStreamParser {
 
     private func parseScrollFrame() -> ParsedFrame? {
         let localBuffer = Data(self.buffer)
-        Logger.debug("Buffer: \(localBuffer.map { String(format: "%02X", $0) }.joined(separator: " "))", category: .network)
         
         guard let soiRange = localBuffer.range(of: Data([0xFF, 0xD8])) else {
             return nil

--- a/HonestHouse/HonestHouse/Sources/Presentation/Live/LiveStreamView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Live/LiveStreamView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct LiveStreamView: View {
     @EnvironmentObject var container: DIContainer
     @EnvironmentObject var cameraConnectionManager: CameraConnectionManager
-    
+
     @State var vm: LiveStreamViewModel
 
     var body: some View {
@@ -42,7 +42,7 @@ struct LiveStreamView: View {
             HStack(spacing: 15) {
                 Button {
                     Task {
-                        await startLiveView()
+                        vm.startStreaming()
                     }
                 } label: {
                     Text(vm.isStreaming ? "스트리밍 중" : "라이브뷰 시작")
@@ -55,8 +55,7 @@ struct LiveStreamView: View {
 
                 Button {
                     Task {
-                        // TODO: 제대로 동작하게 수정 필요
-                        await stopLiveView()
+                        vm.stopStreaming()
                     }
                 } label: {
                     Text("중지")
@@ -69,23 +68,5 @@ struct LiveStreamView: View {
             }
         }
         .padding()
-    }
-
-    @MainActor
-    private func startLiveView() async {
-        guard cameraConnectionManager.connectionState == .connected else {
-            vm.errorMessage = "먼저 카메라를 연결하세요"
-            return
-        }
-
-        vm.errorMessage = nil
-        vm.startLiveView()
-        Logger.info("라이브뷰 시작", category: .ui)
-    }
-
-    @MainActor
-    private func stopLiveView() async {
-        vm.stopLiveView()
-        Logger.info("라이브뷰 중지", category: .ui)
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Live/LiveStreamView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Live/LiveStreamView.swift
@@ -8,9 +8,6 @@
 import SwiftUI
 
 struct LiveStreamView: View {
-    @EnvironmentObject var container: DIContainer
-    @EnvironmentObject var cameraConnectionManager: CameraConnectionManager
-
     @State var vm: LiveStreamViewModel
 
     var body: some View {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Live/LiveStreamView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Live/LiveStreamView.swift
@@ -23,50 +23,10 @@ struct LiveStreamView: View {
                 Text("라이브뷰 대기 중")
                     .foregroundColor(.gray)
             }
-
-            Text("상태: \(cameraConnectionManager.connectionState == .connected ? (vm.isStreaming ? "스트리밍" : "연결됨") : "연결 안 됨")")
-                .font(.caption)
-                .foregroundColor(cameraConnectionManager.connectionState == .connected ? (vm.isStreaming ? .green : .orange) : .gray)
-
-            if vm.isStreaming {
-                Text("FPS: \(String(format: "%.1f", vm.fps))")
-                    .font(.caption)
-            }
-
-            if let error = vm.errorMessage {
-                Text("에러: \(error)")
-                    .font(.caption)
-                    .foregroundColor(.red)
-            }
-
-            HStack(spacing: 15) {
-                Button {
-                    Task {
-                        vm.startStreaming()
-                    }
-                } label: {
-                    Text(vm.isStreaming ? "스트리밍 중" : "라이브뷰 시작")
-                        .padding()
-                        .background(vm.isStreaming ? Color.orange : Color.green)
-                        .foregroundColor(.white)
-                        .cornerRadius(8)
-                }
-                .disabled(cameraConnectionManager.connectionState != .connected || vm.isStreaming)
-
-                Button {
-                    Task {
-                        vm.stopStreaming()
-                    }
-                } label: {
-                    Text("중지")
-                        .padding()
-                        .background(Color.red)
-                        .foregroundColor(.white)
-                        .cornerRadius(8)
-                }
-                .disabled(!vm.isStreaming)
-            }
         }
         .padding()
+        .task {
+            await vm.observeViewLifecycle()
+        }
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Live/LiveStreamViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Live/LiveStreamViewModel.swift
@@ -24,12 +24,29 @@ final class LiveStreamViewModel {
     private var frameStream: AsyncStream<ParsedFrame>?
     private var frameContinuation: AsyncStream<ParsedFrame>.Continuation?
     private var renderTask: Task<Void, Never>?
+    private var lifecycleTask: Task<Void, Never>?
 
     init(container: DIContainer) {
         self.container = container
     }
+    
+    func observeViewLifecycle() async {
+        defer {
+            Logger.info("View lifecycle ended - cleaning up", category: .viewModel)
+            stopStreaming()
+        }
 
-    func startStreaming() {
+        configureStreaming()
+
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(0.5))
+        }
+
+        Logger.info("Task cancellation detected", category: .viewModel)
+    }
+
+
+    private func configureStreaming() {
         guard !isStreaming else {
             Logger.warning("Already streaming", category: .viewModel)
             return
@@ -68,12 +85,15 @@ final class LiveStreamViewModel {
         }
     }
 
-    func stopStreaming() {
+    private func stopStreaming() {
         guard isStreaming else {
             Logger.warning("Not streaming", category: .viewModel)
             return
         }
-
+        
+        lifecycleTask?.cancel()
+        lifecycleTask = nil
+        
         frameContinuation?.finish()
         frameContinuation = nil
         renderTask?.cancel()
@@ -86,8 +106,9 @@ final class LiveStreamViewModel {
                 currentImage = nil
                 afFrames.removeAll()
                 fps = 0.0
+                Logger.info("Streaming stopped successfully", category: .viewModel)
             } catch {
-                errorMessage = "Failed to stop live view: \(error.localizedDescription)"
+                Logger.error("Stop streaming error: \(error)", category: .viewModel)
             }
         }
     }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Live/LiveStreamViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Live/LiveStreamViewModel.swift
@@ -45,7 +45,6 @@ final class LiveStreamViewModel {
         Logger.info("Task cancellation detected", category: .viewModel)
     }
 
-
     private func configureStreaming() {
         guard !isStreaming else {
             Logger.warning("Already streaming", category: .viewModel)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Live/LiveStreamViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Live/LiveStreamViewModel.swift
@@ -9,36 +9,48 @@ import SwiftUI
 
 @Observable
 final class LiveStreamViewModel {
-
     private let container: DIContainer
-    
+
     var isStreaming = false
     var currentImage: UIImage?
     var afFrames: [LiveViewInfo.AFFrame] = []
-    var errorMessage: String?
+    var errorMessage: String? //TODO: Error State로 변경
     var fps: Double = 0.0
-    
+
     private var frameCount = 0
     private var fpsStartTime = Date()
     private let fpsUpdateInterval: TimeInterval = 1.0
-    
+
+    private var frameStream: AsyncStream<ParsedFrame>?
+    private var frameContinuation: AsyncStream<ParsedFrame>.Continuation?
+    private var renderTask: Task<Void, Never>?
+
     init(container: DIContainer) {
         self.container = container
     }
 
-    func startLiveView() {
+    func startStreaming() {
         guard !isStreaming else {
             Logger.warning("Already streaming", category: .viewModel)
             return
         }
 
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: ParsedFrame.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+
+        frameStream = stream
+        frameContinuation = continuation
+
         Task { @MainActor in
             let success = await container.services.liveViewService.startLiveView(
                 onFrame: { [weak self] frame in
-                    self?.handleFrame(frame)
+                    self?.frameContinuation?.yield(frame)
                 },
                 onError: { [weak self] error in
                     self?.handleError(error)
+                    self?.frameContinuation?.finish()
                 },
                 size: "medium",
                 display: "on"
@@ -48,17 +60,24 @@ final class LiveStreamViewModel {
                 isStreaming = true
                 errorMessage = nil
                 resetFPS()
+                startRenderLoop()
             } else {
                 errorMessage = "Failed to start live view"
+                frameContinuation?.finish()
             }
         }
     }
 
-    func stopLiveView() {
+    func stopStreaming() {
         guard isStreaming else {
             Logger.warning("Not streaming", category: .viewModel)
             return
         }
+
+        frameContinuation?.finish()
+        frameContinuation = nil
+        renderTask?.cancel()
+        renderTask = nil
 
         Task { @MainActor in
             do {
@@ -66,9 +85,28 @@ final class LiveStreamViewModel {
                 isStreaming = false
                 currentImage = nil
                 afFrames.removeAll()
+                fps = 0.0
             } catch {
                 errorMessage = "Failed to stop live view: \(error.localizedDescription)"
             }
+        }
+    }
+
+    private func startRenderLoop() {
+        renderTask = Task { @MainActor in
+            guard let stream = frameStream else { return }
+            Logger.info("Render loop started", category: .viewModel)
+
+            for await frame in stream {
+                guard !Task.isCancelled else {
+                    Logger.info("Render loop cancelled", category: .viewModel)
+                    break
+                }
+
+                handleFrame(frame)
+            }
+
+            Logger.info("Render loop ended", category: .viewModel)
         }
     }
 
@@ -98,6 +136,9 @@ final class LiveStreamViewModel {
         isStreaming = false
         errorMessage = "Connection error: \(error.localizedDescription)"
         Logger.error("LiveView error: \(error)", category: .viewModel)
+
+        frameContinuation?.finish()
+        renderTask?.cancel()
     }
 
     private func updateFPS() {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Main/View/MainView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Main/View/MainView.swift
@@ -92,13 +92,11 @@ struct MainView: View {
     
     @ViewBuilder
     private func selectedSegmentView() -> some View {
-        switch vm.selectedSegment {
-        case .trishot:
+        if vm.selectedSegment == .trishot {
             TrishotSettingView(
                 vm: TrishotSettingViewModel(container: container)
             )
-            
-        case .preset:
+        } else if vm.selectedSegment == .preset {
             PresetView(
                 vm: PresetViewModel(
                     container: container,

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
@@ -54,22 +54,9 @@ struct PresetDetailView: View {
         }
     }
     
-    // Preview Section
     private func previewView() -> some View {
         ZStack {
-            // Sample Image (구름 사진)
-            Image(systemName: "cloud.fill")
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .clipped()
-                .overlay(
-                    LinearGradient(
-                        colors: [Color.clear, Color.black.opacity(0.3)],
-                        startPoint: .top,
-                        endPoint: .bottom
-                    )
-                )
+            LiveStreamView(vm: LiveStreamViewModel(container: vm.container))
         }
     }
     

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/EventMonitorService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/EventMonitorService.swift
@@ -34,7 +34,7 @@ final class EventMonitorService: StreamService, EventMonitorServiceType {
         onError: @escaping (Error) -> Void
     ) async -> Bool {
         return await startStreaming(
-            onData: { [weak self] data in
+            onDataReceived: { [weak self] data in
                 self?.handleReceivedData(data, onEvent: onEvent)
             },
             onError: onError

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/Stream/StreamService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/Stream/StreamService.swift
@@ -23,7 +23,7 @@ class StreamService: BaseStreamService {
 
     @discardableResult
     func startStreaming(
-        onData: @escaping (Data) -> Void,
+        onDataReceived: @escaping (Data) -> Void,
         onError: @escaping (Error) -> Void
     ) async -> Bool {
         guard !isStreaming else {
@@ -45,7 +45,7 @@ class StreamService: BaseStreamService {
         let config = createSessionConfiguration()
 
         let delegate = StreamDelegate(
-            onData: onData,
+            onBinaryDataReceived: onDataReceived,
             onError: onError,
             sslHandler: handleSSLChallenge
         )
@@ -108,16 +108,16 @@ class StreamService: BaseStreamService {
 
 private class StreamDelegate: NSObject, URLSessionDataDelegate {
     private var buffer = Data()
-    private let onData: (Data) -> Void
+    private let onBinaryDataReceived: (Data) -> Void
     private let onError: (Error) -> Void
     private let sslHandler: (URLAuthenticationChallenge, @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void
 
     init(
-        onData: @escaping (Data) -> Void,
+        onBinaryDataReceived: @escaping (Data) -> Void,
         onError: @escaping (Error) -> Void,
         sslHandler: @escaping (URLAuthenticationChallenge, @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void
     ) {
-        self.onData = onData
+        self.onBinaryDataReceived = onBinaryDataReceived
         self.onError = onError
         self.sslHandler = sslHandler
     }
@@ -130,7 +130,7 @@ private class StreamDelegate: NSObject, URLSessionDataDelegate {
         Logger.debug("Received chunk: \(data.count) bytes, buffer total: \(buffer.count) bytes", category: .network)
         Logger.debug("First 20 bytes: \(dataCopy.prefix(20).map { String(format: "%02X", $0) }.joined(separator: " "))", category: .network)
 
-        onData(dataCopy)
+        onBinaryDataReceived(dataCopy)
 
         buffer.removeAll()
     }

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/StreamDownload/StreamDownloadDelegate.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/StreamDownload/StreamDownloadDelegate.swift
@@ -10,28 +10,18 @@ import Foundation
 /// 점진적 다운로드의 JSON 파싱 델리게이트
 /// - URLSessionDataDelegate 구현
 /// - 실시간으로 완성된 JSON 객체를 파싱하여 콜백
-import Foundation
-
-/// Chunked 스트림의 URLSessionDataDelegate
 final class StreamDownloadDelegate<T: Decodable>: NSObject, URLSessionDataDelegate {
-    
-    // MARK: - Properties
     
     private let onProgress: ([T]) -> Void
     private let onComplete: ([T]) -> Void
     private let sslHandler: (URLAuthenticationChallenge, @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void
     
     var completion: ((Result<Void, Error>) -> Void)?
+    
     private var hasCompleted = false
-    
-    // MARK: - Parsing State
-    
-    private var textBuffer = ""  // 텍스트 버퍼만 유지
+    private var textBuffer = ""
     private var parsedObjects: [T] = []
-    
     private let decoder = JSONDecoder()
-    
-    // MARK: - Initialization
     
     init(
         decodingType: T.Type,
@@ -44,29 +34,25 @@ final class StreamDownloadDelegate<T: Decodable>: NSObject, URLSessionDataDelega
         self.sslHandler = sslHandler
     }
     
-    // MARK: - URLSessionDataDelegate
-    
     func urlSession(
         _ session: URLSession,
         dataTask: URLSessionDataTask,
         didReceive data: Data
     ) {
         guard let newText = String(data: data, encoding: .utf8) else {
-            print("⚠️ Failed to decode chunk as UTF-8")
+            Logger.warning("Failed to decode chunk as UTF-8", category: .network)
             return
         }
         
-        // 버퍼에 추가
         textBuffer.append(newText)
         
-        print("📥 Received \(data.count) bytes, buffer: \(textBuffer.count) chars")
+        Logger.debug("Received \(data.count) bytes, buffer: \(textBuffer.count) chars", category: .network)
         
-        // 완성된 JSON 객체들 파싱
         let newlyParsed = extractAndParseJSONObjects()
         
         if !newlyParsed.isEmpty {
             parsedObjects.append(contentsOf: newlyParsed)
-            print("✅ Parsed \(newlyParsed.count) objects (Total: \(parsedObjects.count))")
+            Logger.debug("Parsed \(newlyParsed.count) objects (Total: \(parsedObjects.count))", category: .network)
             onProgress(parsedObjects)
         }
     }
@@ -82,10 +68,10 @@ final class StreamDownloadDelegate<T: Decodable>: NSObject, URLSessionDataDelega
             return
         }
         
-        print("📡 Response status: \(httpResponse.statusCode)")
+        Logger.debug("Response status: \(httpResponse.statusCode)", category: .network)
         
         if validateResponseStatus(httpResponse.statusCode) != nil {
-            print("⚠️ Invalid status code, cancelling task")
+            Logger.warning("Invalid status code, cancelling task", category: .network)
             completionHandler(.cancel)
             return
         }
@@ -99,25 +85,24 @@ final class StreamDownloadDelegate<T: Decodable>: NSObject, URLSessionDataDelega
         didCompleteWithError error: Error?
     ) {
         guard !hasCompleted else {
-            print("⚠️ Already completed, ignoring")
+            Logger.warning("Already completed, ignoring", category: .network)
             return
         }
         
         hasCompleted = true
         
-        // 남은 버퍼 처리
         if !textBuffer.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            print("⚠️ Processing remaining buffer: \(textBuffer.count) chars")
+            Logger.warning("Processing remaining buffer: \(textBuffer.count) chars", category: .network)
             let remaining = extractAndParseJSONObjects()
             if !remaining.isEmpty {
                 parsedObjects.append(contentsOf: remaining)
-                print("✅ Parsed \(remaining.count) remaining objects")
+                Logger.debug("Parsed \(remaining.count) remaining objects", category: .network)
             }
         }
         
         if let error = error {
             if (error as NSError).code == NSURLErrorCancelled {
-                print("⚠️ Task cancelled")
+                Logger.warning("Task cancelled", category: .network)
                 if let httpResponse = task.response as? HTTPURLResponse,
                    let statusError = validateResponseStatus(httpResponse.statusCode) {
                     completion?(.failure(statusError))
@@ -125,11 +110,11 @@ final class StreamDownloadDelegate<T: Decodable>: NSObject, URLSessionDataDelega
                     completion?(.failure(error))
                 }
             } else {
-                print("❌ Stream error: \(error)")
+                Logger.error("Stream error: \(error)", category: .network)
                 completion?(.failure(error))
             }
         } else {
-            print("✅ Stream completed: \(parsedObjects.count) objects")
+            Logger.info("Stream completed: \(parsedObjects.count) objects", category: .network)
             onComplete(parsedObjects)
             completion?(.success(()))
         }
@@ -143,24 +128,19 @@ final class StreamDownloadDelegate<T: Decodable>: NSObject, URLSessionDataDelega
         handleSSLChallenge(challenge, completionHandler: completionHandler)
     }
     
-    // MARK: - Private Methods - Parsing
-    
     /// 완성된 JSON 객체들을 추출하고 파싱
     private func extractAndParseJSONObjects() -> [T] {
         var parsed: [T] = []
         
         while true {
-            // 다음 JSON 객체 찾기
             guard let (jsonString, consumedLength) = extractNextJSONObject() else {
                 break
             }
             
-            // JSON 파싱
             if let object = decodeJSONObject(from: jsonString) {
                 parsed.append(object)
             }
             
-            // 파싱된 부분 제거
             textBuffer.removeFirst(consumedLength)
         }
         
@@ -179,7 +159,6 @@ final class StreamDownloadDelegate<T: Decodable>: NSObject, URLSessionDataDelega
         for index in textBuffer.indices {
             let char = textBuffer[index]
             
-            // 문자열 내부 처리
             if escapeNext {
                 escapeNext = false
                 continue
@@ -195,7 +174,6 @@ final class StreamDownloadDelegate<T: Decodable>: NSObject, URLSessionDataDelega
                 continue
             }
             
-            // 문자열 밖에서만 중괄호 카운트
             if !inString {
                 if char == "{" {
                     if braceCount == 0 {
@@ -205,7 +183,6 @@ final class StreamDownloadDelegate<T: Decodable>: NSObject, URLSessionDataDelega
                 } else if char == "}" {
                     braceCount -= 1
                     
-                    // 완전한 JSON 객체 완성
                     if braceCount == 0, let start = objectStart {
                         objectEnd = textBuffer.index(after: index)
                         
@@ -218,7 +195,6 @@ final class StreamDownloadDelegate<T: Decodable>: NSObject, URLSessionDataDelega
             }
         }
         
-        // 완성된 객체 없음
         return nil
     }
     
@@ -234,22 +210,20 @@ final class StreamDownloadDelegate<T: Decodable>: NSObject, URLSessionDataDelega
         do {
             return try decoder.decode(T.self, from: jsonData)
         } catch {
-            print("⚠️ JSON decode error: \(error)")
+            Logger.warning("JSON decode error: \(error)", category: .network)
             return nil
         }
     }
-    
-    // MARK: - Private Methods - Validation
     
     private func validateResponseStatus(_ statusCode: Int) -> Error? {
         switch statusCode {
         case 200...299:
             return nil
         case 401:
-            print("⚠️ 401 Unauthorized")
+            Logger.warning("401 Unauthorized", category: .network)
             return CCAPIError.authenticationFailed(401)
         default:
-            print("⚠️ Unexpected status: \(statusCode)")
+            Logger.warning("Unexpected status: \(statusCode)", category: .network)
             return CCAPIError.unexpectedStatusCode(statusCode)
         }
     }

--- a/HonestHouse/HonestHouse/Sources/Service/LiveViewService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/LiveViewService.swift
@@ -51,7 +51,7 @@ final class LiveViewService: StreamService, LiveViewServiceType {
             await parser.reset()
 
             return await startStreaming(
-                onData: { [weak self] data in
+                onDataReceived: { [weak self] data in
                     guard let self = self else { return }
                     Task {
                         await self.parser.appendChunk(data)


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #76 

---
  
### 🧶 주요 변경 내용 (Summary)
- 스트리밍을 시작하면 처음 몇 초만 화면이 나온 후 멈추는 오류를 해결했습니다
- 스트리밍 화면의 생명주기가 끝나도 영상 이진 데이터 스트림이 끊기지 않고 지속되는 오류를 해결했습니다.

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="400" alt="예시 이미지" src="https://github.com/user-attachments/assets/d048eaef-43dc-4cf6-8f63-98a79e64f194">

---

### 💬 기타 공유 사항

- `AsyncStream`을 사용해서 프레임을 비동기처리하여 스트리밍 문제를 해결했습니다.
- PresetDetailView의 생명주기에 따라 Streaming을 시작하고 중단하고자 했으나, 적용 후에 확인해보니 아직 완전히 의도대로 작동하지 않아서 추후 수정 예정 ...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 프리셋 상세 화면에 실시간 스트림 미리보기 추가

* **개선 사항**
  * 실시간 스트림 보기 UI 간소화 — 상태 표시, FPS 표시 및 시작/중지 컨트롤 제거
  * 뷰 수명 주기 기반 스트리밍 처리로 안정성 및 상태 관리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->