### PR TITLE
Refactor: #88 MainView 카메라 연결 sheet 연결

### DIFF
--- a/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/CameraConnectionView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/CameraConnectionView.swift
@@ -24,7 +24,7 @@ struct CameraConnectionView: View {
                         Button {
                             dismiss()
                         } label: {
-                            Image("closeIcon")
+                            Image(.closeIcon)
                                 .resizable()
                                 .frame(width: 36, height: 36)
                         }

--- a/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/ConnectionGuideView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/CameraConnection/ConnectionGuideView.swift
@@ -85,7 +85,7 @@ struct ConnectionGuideView: View {
     
     // TODO: IP 직접 입력 후 연결 구현 필요
     private func ipAddressTextField() -> some View {
-        TextField("http://192.168.1.2:8080/ccapi/", text: $ipAddress)
+        TextField("https://192.168.1.2:443/ccapi/", text: $ipAddress)
             .font(.num4)
             .foregroundColor(.g0)
             .multilineTextAlignment(.center)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Main/View/MainView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Main/View/MainView.swift
@@ -45,7 +45,9 @@ struct MainView: View {
     private func cameraAndArchiveHeaderView() -> some View {
         HStack {
             Button {
-                // TODO: 카메라 연결
+                if cameraConnectionManager.connectionState != .connected {
+                    cameraConnectionManager.showConnectionSheet = true
+                }
             } label: {
                 Image(.setting)
                     .resizable()

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/SettingButton.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/Component/SettingButton.swift
@@ -119,6 +119,13 @@ struct ShootingModeSelector: View {
                     }
                 } label: {
                     Text(mode.rawValue)
+                        .font(.num6)
+                        .foregroundStyle(Color.g0)
+                        .padding(15)
+                        .clipShape(Circle())
+                        .overlay {
+                            Circle().strokeBorder(Color.g0, lineWidth: 1)
+                        }
                 }
             }
         }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/Models.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/Models.swift
@@ -25,7 +25,7 @@ enum SettingType: String {
     case aperture = "f"
     case shutterSpeed = "s"
     case iso = "ISO"
-    case pictureStyle = "pictureStyle"
+    case pictureStyle = "Style"
     
     case tintMagentaGreen = "TintMG"
     case exposure = "Exp"

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
@@ -41,6 +41,7 @@ struct PresetDetailView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
         .toolbar {
             toolbarContent()
         }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetDetailView.swift
@@ -75,6 +75,17 @@ struct PresetDetailView: View {
     // Primary Settings Section
     private func primarySettingsView() -> some View {
         HStack {
+            
+//            SettingButton(
+//                type: .cameraMode,
+//                state: vm.getButtonState(for: .cameraMode),
+//                value: vm.currentPreset.shootingMode,
+//                isSelected: vm.activePicker == .cameraMode,
+//                action: {
+//                    handleSettingButtonTap(.cameraMode)
+//                }
+//            )
+            
             // Aperture (조리개)
             SettingButton(
                 type: .aperture,
@@ -127,7 +138,14 @@ struct PresetDetailView: View {
     private func pickerView(for type: SettingType) -> some View {
         switch type {
         case .cameraMode:
-            EmptyView()
+            NonOptionalWheelPickerView(
+                selectedValue: $vm.currentPreset.shootingMode,
+                items: vm.getCameraShootingModeValues(),
+                config: .init(
+                    spacing: 22,
+                    itemSize: .init(width: 50, height: 24)
+                )
+            )
             
         case .aperture:
             if vm.currentPreset.shootingMode == .av {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
@@ -207,6 +207,10 @@ class PresetDetailViewModel {
     }
     
     // Get Setting Values
+    func getCameraShootingModeValues() -> [ShootingModeType] {
+        return ShootingModeType.allCases
+    }
+    
     func getISOValues() -> [String] {
         return CameraConstants.isoValues
     }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #88 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- `MainView` CameraConnectionSheet 연결
- `PresetDetailView`의 기본 `navigationBarBackButton` 숨김

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] Simulator - iPhone 17 Pro, iOS 26.1 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->


---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카메라 미연결 상태에서 버튼 클릭 시 연결 화면이 자동으로 표시됩니다.

* **UI 개선**
  * 프리셋 상세 화면의 뒤로 가기 버튼을 숨겼습니다.
  * 카메라 연결 가이드 권장 접속 정보가 HTTPS/443으로 업데이트되었습니다.
  * 프리셋의 카메라 모드가 실제 휠형 선택기(값 목록 제공)로 표시되도록 변경되었습니다.
  * 촬영 모드 선택 레이블에 원형 스타일 및 시각적 개선을 적용했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->