### PR TITLE
Feat: #92 Archive DetailView Zoom Gesture 구현

### DIFF
--- a/HonestHouse/HonestHouse/Sources/Core/Network/Foundation/BaseURLConstants.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/Foundation/BaseURLConstants.swift
@@ -7,6 +7,6 @@
 
 enum BaseURLConstants {
     static let cameraIP = "192.168.1.2"
-    static let port = "8080"
-    static let baseURL = "http://\(cameraIP):\(port)/ccapi/"
+    static let port = "443"
+    static let baseURL = "https://\(cameraIP):\(port)/ccapi/"
 }

--- a/HonestHouse/HonestHouse/Sources/Core/Network/Foundation/BaseURLConstants.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/Foundation/BaseURLConstants.swift
@@ -7,6 +7,6 @@
 
 enum BaseURLConstants {
     static let cameraIP = "192.168.1.2"
-    static let port = "443"
-    static let baseURL = "https://\(cameraIP):\(port)/ccapi/"
+    static let port = "8080"
+    static let baseURL = "http://\(cameraIP):\(port)/ccapi/"
 }

--- a/HonestHouse/HonestHouse/Sources/Extension/View+Extension.swift
+++ b/HonestHouse/HonestHouse/Sources/Extension/View+Extension.swift
@@ -67,4 +67,23 @@ extension View {
             }
         }
     }
+    
+    /*
+    Pinch to zoom
+    Double tap to zoom in and out
+    Drag to pan
+    */
+    func zoomableGesture(
+        minZoomScale: CGFloat = 1.0,
+        maxZoomScale: CGFloat = 3.0,
+        doubleTapZoomScale: CGFloat = 3.0
+    ) -> some View {
+        ZoomableGestureView(
+            minZoomScale: minZoomScale,
+            maxZoomScale: maxZoomScale,
+            doubleTapZoomScale: doubleTapZoomScale
+        ) {
+            self
+        }
+    }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/ProgressiveDisplayImageView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/ProgressiveDisplayImageView.swift
@@ -13,7 +13,6 @@ struct ProgressiveDisplayImageView: View {
     @State private var shouldUseFallback = false
     
     let photo: Photo
-    let onImageLoaded: (() -> Void)?  // 이미지 로딩 완료 콜백
     
     
     var body: some View {
@@ -33,9 +32,6 @@ struct ProgressiveDisplayImageView: View {
             .placeholder {
                 thumbnailImageView(url: photo.thumbnailURL)
             }
-            .onSuccess { _ in
-                onImageLoaded?()
-            }
             .onFailure { error in
                 print("[Display] Failed: \(photo.displayURL) - \(error.localizedDescription)")
                 print("[Fallback] Using original: \(photo.url)")
@@ -52,9 +48,6 @@ struct ProgressiveDisplayImageView: View {
         KFImage(URL(string: url))
             .placeholder {
                 thumbnailImageView(url: photo.thumbnailURL)
-            }
-            .onSuccess { _ in
-                onImageLoaded?()
             }
             .retry(maxCount: 2, interval: .seconds(2))
             .cacheOriginalImage()

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/ZoomableGestureView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/ZoomableGestureView.swift
@@ -1,0 +1,215 @@
+//
+//  ZoomableGestureView.swift
+//  HonestHouse
+//
+//  Created by 이현주 on 11/11/25.
+//
+
+import SwiftUI
+
+struct ZoomableGestureView<Content: View>: View {
+    let content: Content
+    let minZoomScale: CGFloat
+    let maxZoomScale: CGFloat
+    let doubleTapZoomScale: CGFloat
+    
+    @State private var contentSize: CGSize = .zero
+    @State private var viewID = UUID()
+    
+    init(
+        minZoomScale: CGFloat = 1.0,
+        maxZoomScale: CGFloat = 3.0,
+        doubleTapZoomScale: CGFloat = 3.0,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.minZoomScale = minZoomScale
+        self.maxZoomScale = maxZoomScale
+        self.doubleTapZoomScale = doubleTapZoomScale
+        self.content = content()
+    }
+    
+    var body: some View {
+        ZoomScrollViewRepresentable(
+            content: content,
+            minZoomScale: minZoomScale,
+            maxZoomScale: maxZoomScale,
+            doubleTapZoomScale: doubleTapZoomScale
+        )
+        .background(
+            // 실제 컨텐츠 크기 측정
+            GeometryReader { geometry in
+                Color.clear
+                    .onAppear { // 처음 나타날 때 사이즈
+                        contentSize = geometry.size
+                    }
+                    .onChange(of: geometry.size) { _, newSize in // 크기 변경 시 사이즈
+                        contentSize = newSize
+                    }
+            }
+        )
+        .id(viewID)  // 뷰 재생성
+        .onDisappear {
+            // TabView 전환 시 ID 변경
+            DispatchQueue.main.async {
+                viewID = UUID()
+            }
+        }
+    }
+}
+
+// MARK: - UIViewRepresentable Implementation
+private struct ZoomScrollViewRepresentable<Content: View>: UIViewRepresentable {
+    let content: Content
+    let minZoomScale: CGFloat
+    let maxZoomScale: CGFloat
+    let doubleTapZoomScale: CGFloat
+    
+    func makeUIView(context: Context) -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.delegate = context.coordinator
+        scrollView.minimumZoomScale = minZoomScale
+        scrollView.maximumZoomScale = maxZoomScale
+        scrollView.bouncesZoom = true
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.clipsToBounds = false // tabView 스와이프 허용
+        scrollView.backgroundColor = .clear
+        
+        // SwiftUI 컨텐츠를 UIHostingController로 래핑
+        let hostingController = UIHostingController(rootView: content)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = true
+        hostingController.view.backgroundColor = .clear
+        
+        // sizeToFit()으로 실제 컨텐츠 크기 계산
+        hostingController.view.sizeToFit()
+        
+        scrollView.addSubview(hostingController.view)
+        
+        context.coordinator.hostingController = hostingController
+        context.coordinator.scrollView = scrollView
+        
+        // 더블 탭 제스처
+        let doubleTapGesture = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleDoubleTap(_:))
+        )
+        doubleTapGesture.numberOfTapsRequired = 2
+        scrollView.addGestureRecognizer(doubleTapGesture)
+        
+        // 초기 레이아웃
+        DispatchQueue.main.async {
+            context.coordinator.layoutContent()
+        }
+        
+        return scrollView
+    }
+    
+    func updateUIView(_ uiView: UIScrollView, context: Context) {
+        uiView.minimumZoomScale = minZoomScale
+        uiView.maximumZoomScale = maxZoomScale
+        context.coordinator.hostingController?.rootView = content
+        
+        // 레이아웃 업데이트
+        DispatchQueue.main.async {
+            context.coordinator.layoutContent()
+        }
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            doubleTapZoomScale: doubleTapZoomScale,
+            maxZoomScale: maxZoomScale,
+            minZoomScale: minZoomScale
+        )
+    }
+    
+    // MARK: - Coordinator
+    class Coordinator: NSObject, UIScrollViewDelegate {
+        var hostingController: UIHostingController<Content>?
+        weak var scrollView: UIScrollView?
+        let doubleTapZoomScale: CGFloat
+        let maxZoomScale: CGFloat
+        let minZoomScale: CGFloat
+        
+        init(doubleTapZoomScale: CGFloat, maxZoomScale: CGFloat, minZoomScale: CGFloat) {
+            self.doubleTapZoomScale = doubleTapZoomScale
+            self.maxZoomScale = maxZoomScale
+            self.minZoomScale = minZoomScale
+        }
+        
+        // 줌할 뷰 반환
+        func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+            return hostingController?.view
+        }
+        
+        func scrollViewDidZoom(_ scrollView: UIScrollView) {
+            centerContent(in: scrollView)
+        }
+        
+        // 레이아웃 업데이트
+        func layoutContent() {
+            guard let hostingView = hostingController?.view,
+                  let scrollView = scrollView else { return }
+            
+            // 컨텐츠 실제 크기 계산
+            let contentSize = hostingView.systemLayoutSizeFitting(
+                scrollView.bounds.size,
+                withHorizontalFittingPriority: .fittingSizeLevel,
+                verticalFittingPriority: .fittingSizeLevel
+            )
+            
+            // 컨텐츠 크기 설정
+            hostingView.frame.size = contentSize
+            scrollView.contentSize = contentSize
+            
+            // 중앙 정렬
+            centerContent(in: scrollView)
+        }
+        
+        @objc func handleDoubleTap(_ gesture: UITapGestureRecognizer) {
+            guard let scrollView = scrollView,
+                  let hostingView = hostingController?.view else { return }
+            
+            if scrollView.zoomScale > scrollView.minimumZoomScale {
+                scrollView.setZoomScale(scrollView.minimumZoomScale, animated: true)
+            } else {
+                let location = gesture.location(in: hostingView)
+                let zoomScale = min(doubleTapZoomScale, maxZoomScale)
+                
+                // 탭한 위치를 중심으로 하는 사각형 계산
+                let size = scrollView.bounds.size
+                let w = size.width / zoomScale
+                let h = size.height / zoomScale
+                // 사각형 중심이 탭 위치가 되도록
+                let x = location.x - (w / 2.0)
+                let y = location.y - (h / 2.0)
+                
+                let rectToZoom = CGRect(x: x, y: y, width: w, height: h)
+                scrollView.zoom(to: rectToZoom, animated: true)
+            }
+        }
+        
+        private func centerContent(in scrollView: UIScrollView) {
+            guard let view = hostingController?.view else { return }
+            
+            let boundsSize = scrollView.bounds.size // 화면 크기
+            var frameToCenter = view.frame // 컨텐츠 프레임
+            
+            // 수평 중앙 정렬
+            if frameToCenter.size.width < boundsSize.width {
+                frameToCenter.origin.x = (boundsSize.width - frameToCenter.size.width) / 2
+            } else {
+                frameToCenter.origin.x = 0
+            }
+            
+            // 수직 중앙 정렬
+            if frameToCenter.size.height < boundsSize.height {
+                frameToCenter.origin.y = (boundsSize.height - frameToCenter.size.height) / 2
+            } else {
+                frameToCenter.origin.y = 0
+            }
+            
+            view.frame = frameToCenter
+        }
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosDetailView.swift
@@ -31,15 +31,11 @@ struct GroupedPhotosDetailView: View {
 
     private func photoDetailView(photo: Photo) -> some View {
         ZStack(alignment: .topLeading) {
-            VStack(spacing: 0) {
-                Spacer()
-                
-                ProgressiveDisplayImageView(
-                    photo: photo
-                )
-                
-                Spacer()
-            }
+            
+            ProgressiveDisplayImageView(
+                photo: photo
+            )
+            .zoomableGesture()
             
             VStack(spacing: 0) {
                 selectionButtonView(photo: photo)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/GroupedPhotosDetailView.swift
@@ -12,8 +12,6 @@ struct GroupedPhotosDetailView: View {
     @Environment(GroupedPhotosViewModel.self) var vm
     @Environment(\.dismiss) private var dismiss
     
-    @State private var loadedImages: Set<String> = [] // 버튼 띄우기 용
-    
     let groupedPhotos: SimilarPhotoGroup
 
     var body: some View {
@@ -32,20 +30,22 @@ struct GroupedPhotosDetailView: View {
     }
 
     private func photoDetailView(photo: Photo) -> some View {
-        ZStack(alignment: .bottomTrailing) {
-            // Progressive Display Image (Thumbnail → Display → Display 실패 시 원본)
-            ProgressiveDisplayImageView(
-                photo: photo,
-                onImageLoaded: {
-                    loadedImages.insert(photo.url)
-                }
-            )
-
-            // 선택/해제 버튼 (이미지 로딩 완료 후 표시)
-            if loadedImages.contains(photo.url) {
+        ZStack(alignment: .topLeading) {
+            VStack(spacing: 0) {
+                Spacer()
+                
+                ProgressiveDisplayImageView(
+                    photo: photo
+                )
+                
+                Spacer()
+            }
+            
+            VStack(spacing: 0) {
                 selectionButtonView(photo: photo)
                     .padding(16)
-                    .transition(.opacity)
+                
+                Spacer()
             }
         }
         .task {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionDetailView.swift
@@ -47,15 +47,11 @@ struct PhotoSelectionDetailView: View {
 
     private func photoDetailView(photo: Photo) -> some View {
         ZStack(alignment: .topLeading) {
-            VStack(spacing: 0) {
-                Spacer()
-                
-                ProgressiveDisplayImageView(
-                    photo: photo
-                )
-                
-                Spacer()
-            }
+            
+            ProgressiveDisplayImageView(
+                photo: photo
+            )
+            .zoomableGesture()
             
             VStack(spacing: 0) {
                 selectionButtonView(photo: photo)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionDetailView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/View/PhotoSelectionDetailView.swift
@@ -14,7 +14,6 @@ struct PhotoSelectionDetailView: View {
 
     @State private var selectedURL: String // TabView 현재 페이지
     @State private var photos: [Photo] = [] // 스냅샷 (vm chunk append시, 무시 목적)
-    @State private var loadedImages: Set<String> = [] // 버튼 띄우기 용
     
     let initialPhoto: Photo
 
@@ -47,18 +46,22 @@ struct PhotoSelectionDetailView: View {
     }
 
     private func photoDetailView(photo: Photo) -> some View {
-        ZStack(alignment: .bottomTrailing) {
-            ProgressiveDisplayImageView(
-                photo: photo,
-                onImageLoaded: {
-                    loadedImages.insert(photo.url)
-                }
-            )
-
-            if loadedImages.contains(photo.url) {
+        ZStack(alignment: .topLeading) {
+            VStack(spacing: 0) {
+                Spacer()
+                
+                ProgressiveDisplayImageView(
+                    photo: photo
+                )
+                
+                Spacer()
+            }
+            
+            VStack(spacing: 0) {
                 selectionButtonView(photo: photo)
                     .padding(16)
-                    .transition(.opacity)
+                
+                Spacer()
             }
         }
         .task {


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #92 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- Archive/Component - ZoomableGestureView, ZoomScrollViewRepresentable로 구현
   - Pinch to zoom
   - Double tap to zoom in and out
   - Drag to pan
- View+Extension에 zoomableGesture 커스텀 수정자 구현 
- DetailView KFImage에 커스텀 수정자 적용

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/e40ce421-9aec-43ea-96ed-d5848d3bdd5e


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

### 왜 UIKit의 UIScrollView 사용?
- SwiftUI Gesture
   - MagnifyGesture(Pinch to Zoom), SpatialTapGesture(Double Tap to Zoom), DragGesture(Drag to Pan)
   - 제스처 독점 (Gesture Exclusivity) -> 한 제스처가 활성화되면 다른 제스처를 차단했음. TabView의 스와이프 제스처 완전 차단됨
   - 그럼 가장자리 감지를 하면 되지 않을까? -> 직접 다 구현해야함 + 복잡하고 적용이 잘 안됨.
- **UIScrollView**
   - 네이티브 가장자리 감지
   - 제스처 협력 (Gesture Cooperation) -> 내부 판단하에 가장자리 or 밖 영역은 부모에게 전달 (TabView가 받음.)
---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 사진 보기에 핀치-투-줌, 더블탭 줌, 드래그 패닝 기능 추가

## 변경 사항
* 네트워크 통신 설정 업데이트
* 사진 상세 화면 레이아웃 개선 및 사용자 경험 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->