### PR TITLE
Refactor: #96 카메라 연결 버전 및 엔드포인트 관리

### DIFF
--- a/HonestHouse/HonestHouse/Sources/Core/Managers/CameraConnectionManager.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Managers/CameraConnectionManager.swift
@@ -29,7 +29,6 @@ final class CameraConnectionManager: BaseService, ObservableObject {
         self.networkManager = networkManager
         
         if let savedCameraType = CameraType.current {
-            connectionState = .connected
             productName = savedCameraType.displayName  // 추가
         }
     }

--- a/HonestHouse/HonestHouse/Sources/Core/Managers/CameraConnectionManager.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Managers/CameraConnectionManager.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Rama on 11/2/25.
 //
+
 import SwiftUI
 
 @MainActor
@@ -14,8 +15,23 @@ final class CameraConnectionManager: BaseService, ObservableObject {
     
     private let networkManager: NetworkManager
     
+    // CameraType.current를 통해 UserDefaults에서 관리되는 값을 사용
+    var connectedCameraType: CameraType? {
+        get {
+            return CameraType.current
+        }
+        set {
+            CameraType.current = newValue
+        }
+    }
+    
     init(networkManager: NetworkManager = .shared) {
         self.networkManager = networkManager
+        
+        if let savedCameraType = CameraType.current {
+            connectionState = .connected
+            productName = savedCameraType.displayName  // 추가
+        }
     }
     
     func connectCamera(ipAddress: String) {
@@ -38,10 +54,13 @@ final class CameraConnectionManager: BaseService, ObservableObject {
                 
                 if let productName = cameraInfo.productName {
                     self.productName = productName
+                    self.connectedCameraType = CameraType(rawValue: productName)
                 }
+                
             } catch {
                 let connectionError = ConnectionError.from(error)
                 self.connectionState = .failed(connectionError)
+                self.connectedCameraType = nil
                 Logger.error(error.localizedDescription, category: .connection)
             }
         }
@@ -49,6 +68,7 @@ final class CameraConnectionManager: BaseService, ObservableObject {
     
     func disconnectCamera() {
         connectionState = .disconnected
+        CameraType.clearCurrent()
     }
     
     func checkConnectionStatus() async -> Bool {

--- a/HonestHouse/HonestHouse/Sources/Core/Model/4.7. Image Operations/5. ContentInfo.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Model/4.7. Image Operations/5. ContentInfo.swift
@@ -12,7 +12,6 @@ struct ContentInfo {
     
     init(dateInfo: String?) {
         if let dateString = dateInfo {
-            self.dateInfo = DateFormatter.apiDateFormatter.date(from: dateString)
             // 타임존 포함
             if let date = DateFormatter.apiDateFormatter.date(from: dateString) {
                 self.dateInfo = date

--- a/HonestHouse/HonestHouse/Sources/Core/Model/4.7. Image Operations/5. ContentInfo.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Model/4.7. Image Operations/5. ContentInfo.swift
@@ -8,12 +8,23 @@
 import Foundation
 
 struct ContentInfo {
-    let dateInfo: Date?
+    var dateInfo: Date?
     
     init(dateInfo: String?) {
-        // String을 Date로 변환
         if let dateString = dateInfo {
             self.dateInfo = DateFormatter.apiDateFormatter.date(from: dateString)
+            // 타임존 포함
+            if let date = DateFormatter.apiDateFormatter.date(from: dateString) {
+                self.dateInfo = date
+            }
+            // 타임존 없음
+            else if let date = DateFormatter.apiDateFormatterWithoutTimezone.date(from: dateString) {
+                self.dateInfo = date
+            }
+            // 파싱 실패
+            else {
+                self.dateInfo = nil
+            }
         } else {
             self.dateInfo = nil
         }

--- a/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.7. ImageOperations/ImageOperationsTarget.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.7. ImageOperations/ImageOperationsTarget.swift
@@ -16,6 +16,25 @@ enum ImageOperationsTarget {
 
 extension ImageOperationsTarget: BaseTargetType {
     var path: String {
+        guard let cameraType = CameraType.current else {
+            return defaultPath
+        }
+        
+        let version = cameraType.imageOperationsVersion
+        
+        switch self {
+        case .getStorageList:
+            return ImageOperationsAPI.storageList.path(with: version)
+
+        case .getDirectoryList(let storage):
+            return ImageOperationsAPI.directoryList(storage).path(with: version)
+
+        case .getContentInfo(let storage, let directory, let fileName):
+            return ImageOperationsAPI.contentInfo(storage, directory, fileName).path(with: version)
+        }
+    }
+    
+    private var defaultPath: String {
         switch self {
         case .getStorageList:
             return ImageOperationsAPI.storageList.path(with: .ver100)

--- a/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.8. Shooting Control/ShootingControlTarget.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.8. Shooting Control/ShootingControlTarget.swift
@@ -13,6 +13,19 @@ enum ShootingControlTarget {
 
 extension ShootingControlTarget: BaseTargetType {
     var path: String {
+        guard let cameraType = CameraType.current else {
+            return defaultPath
+        }
+
+        let version = cameraType.shootingControlVersion
+
+        switch self {
+        case .ignoreShootingMode:
+            return ShootingControlAPI.ignoreShootingMode.path(with: version)
+        }
+    }
+
+    private var defaultPath: String {
         switch self {
         case .ignoreShootingMode:
             return ShootingControlAPI.ignoreShootingMode.path(with: .ver100)

--- a/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.9. Shooting Settings/ShootingSettingsTarget.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/CCAPI/4.9. Shooting Settings/ShootingSettingsTarget.swift
@@ -9,10 +9,8 @@ import Moya
 
 enum ShootingSettingsTarget {
     case getShootingSetting(VersionType)                                         /// 모든 촬영 매개변수
-    case getShootingMode                                                         /// 사진촬영 모드(다이얼 없는)
-    case putShootingMode(ShootingSettings.ShootingModeRequest)                   /// 사진촬영 모드(다이얼 없는)
-    case getShootingModeDial                                                     /// 사진촬영 모드(다이얼 있는)
-    case putShootingModeDial(ShootingSettings.ShootingModeRequest)               /// 사진촬영 모드(다이얼 있는)
+    case getShootingMode                                                         /// 사진촬영 모드
+    case putShootingMode(ShootingSettings.ShootingModeRequest)                   /// 사진촬영 모드
     case getAv                                                                   /// 조리개
     case putAv(ShootingSettings.AVRequest)                                       /// 조리개
     case getTv                                                                   /// 셔터스피드
@@ -33,22 +31,64 @@ enum ShootingSettingsTarget {
 
 extension ShootingSettingsTarget: BaseTargetType {
     var path: String {
+        // UserDefaults에서 카메라 타입 가져오기
+        guard let cameraType = CameraType.current else {
+            // TODO: 에러 처리
+            return defaultPath
+        }
+        
         switch self {
         case .getShootingSetting(let version):
             return ShootingSettingsAPI.getShootingSetting.path(with: version)
             
-        //MARK: R50V용 v110(ver 1.1.0.)으로 변경
-        case .getShootingMode:
-            return ShootingSettingsAPI.shootingMode.path(with: .ver110)
-        //MARK: R50V용 v110(ver 1.1.0.)으로 변경
-        case .putShootingMode:
-            return ShootingSettingsAPI.shootingMode.path(with: .ver110)
+        case .getShootingMode, .putShootingMode:
+            let version = cameraType.shootingSettingsVersion(for: .shootingMode)
+            let endpoint = cameraType.hasShootingModeDial
+            ? ShootingSettingsAPI.shootingModeDial
+            : ShootingSettingsAPI.shootingMode
+            return "\(version.description)/\(endpoint)"
             
-        case .getShootingModeDial:
-            return ShootingSettingsAPI.shootingModeDial.path(with: .ver100)
+        case .getAv, .putAv:
+            let version = cameraType.shootingSettingsVersion(for: .av)
+            return ShootingSettingsAPI.av.path(with: version)
             
-        case .putShootingModeDial:
-            return ShootingSettingsAPI.shootingModeDial.path(with: .ver100)
+        case .getTv, .putTv:
+            let version = cameraType.shootingSettingsVersion(for: .tv)
+            return ShootingSettingsAPI.tv.path(with: version)
+            
+        case .getIso, .putIso:
+            let version = cameraType.shootingSettingsVersion(for: .iso)
+            return ShootingSettingsAPI.iso.path(with: version)
+            
+        case .getExposureCompensation, .putExposureCompensation:
+            let version = cameraType.shootingSettingsVersion(for: .exposureCompensation)
+            return ShootingSettingsAPI.exposureCompensation.path(with: version)
+            
+        case .getWhiteBalance, .putWhiteBalance:
+            let version = cameraType.shootingSettingsVersion(for: .whiteBalance)
+            return ShootingSettingsAPI.whiteBalance.path(with: version)
+            
+        case .getColorTemperature, .putColorTemperature:
+            let version = cameraType.shootingSettingsVersion(for: .colorTemperature)
+            return ShootingSettingsAPI.colorTemperature.path(with: version)
+            
+        case .getWbShift, .putWbShift:
+            let version = cameraType.shootingSettingsVersion(for: .wbShift)
+            return ShootingSettingsAPI.wbShift.path(with: version)
+            
+        case .getPictureStyle, .putPictureStyle:
+            let version = cameraType.shootingSettingsVersion(for: .pictureStyle)
+            return ShootingSettingsAPI.pictureStyle.path(with: version)
+        }
+    }
+    
+    private var defaultPath: String {
+        switch self {
+        case .getShootingSetting(let version):
+            return ShootingSettingsAPI.getShootingSetting.path(with: version)
+            
+        case .getShootingMode, .putShootingMode:
+            return ShootingSettingsAPI.shootingMode.path(with: .ver110)
             
         case .getAv, .putAv:
             return ShootingSettingsAPI.av.path(with: .ver100)
@@ -80,7 +120,6 @@ extension ShootingSettingsTarget: BaseTargetType {
         switch self {
         case .getShootingSetting,
                 .getShootingMode,
-                .getShootingModeDial,
                 .getAv,
                 .getTv,
                 .getIso,
@@ -92,7 +131,6 @@ extension ShootingSettingsTarget: BaseTargetType {
                 return .get
 
         case .putShootingMode,
-                .putShootingModeDial,
                 .putAv,
                 .putTv,
                 .putIso,
@@ -110,7 +148,6 @@ extension ShootingSettingsTarget: BaseTargetType {
         switch self {
         case .getShootingSetting,
                 .getShootingMode,
-                .getShootingModeDial,
                 .getAv,
                 .getTv,
                 .getIso,
@@ -122,9 +159,6 @@ extension ShootingSettingsTarget: BaseTargetType {
             return .requestPlain
     
         case .putShootingMode(let request):
-            return .requestJSONEncodable(request)
-            
-        case .putShootingModeDial(let request):
             return .requestJSONEncodable(request)
 
         case .putAv(let request):

--- a/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.7. Image Operations/1. StorageListResponse.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.7. Image Operations/1. StorageListResponse.swift
@@ -8,7 +8,7 @@
 extension ImageOperations {
     /// 저장소 리스트
     struct StorageListResponse: BaseResponse {
-        let url: [String]?
+        let path: [String]?
     }
 }
 
@@ -16,10 +16,10 @@ extension ImageOperations.StorageListResponse {
     typealias EntityType = StorageList
     
     func toEntity() -> StorageList {
-        StorageList(url: url)
+        StorageList(url: path)
     }
     
     static var stub1: ImageOperations.StorageListResponse {
-        .init(url: [""])
+        .init(path: [""])
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.7. Image Operations/2. DirectoryListResponse.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.7. Image Operations/2. DirectoryListResponse.swift
@@ -8,7 +8,7 @@
 extension ImageOperations {
     /// 디렉토리 리스트
     struct DirectoryListResponse: BaseResponse {
-        let url: [String]?
+        let path: [String]?
     }
 }
 
@@ -16,10 +16,10 @@ extension ImageOperations.DirectoryListResponse {
     typealias EntityType = DirectoryList
     
     func toEntity() -> DirectoryList {
-        DirectoryList(url: url)
+        DirectoryList(url: path)
     }
     
     static var stub1: ImageOperations.DirectoryListResponse {
-        .init(url: [""])
+        .init(path: [""])
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.7. Image Operations/3. ContentListResponse.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.7. Image Operations/3. ContentListResponse.swift
@@ -8,7 +8,7 @@
 extension ImageOperations {
     /// 콘텐츠 리스트
     struct ContentListResponse: BaseResponse {
-        let url: [String]?
+        let path: [String]?
     }
 }
 
@@ -16,11 +16,11 @@ extension ImageOperations.ContentListResponse {
     typealias EntityType = ContentList
     
     func toEntity() -> ContentList {
-        ContentList(url: url)
+        ContentList(url: path)
     }
     
     static var stub1: ImageOperations.ContentListResponse {
-        .init(url: [""])
+        .init(path: [""])
     }
 }
 

--- a/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.7. Image Operations/5. ContentInfoResponse.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/DTO/Response/4.7. Image Operations/5. ContentInfoResponse.swift
@@ -17,6 +17,7 @@ extension ImageOperations {
         let rating: String
         let lastmodifieddate: String
         let playtime: Int?
+        let hdr: String
     }
 }
 
@@ -35,7 +36,8 @@ extension ImageOperations.ContentInfoResponse {
             rotate: "",
             rating: "",
             lastmodifieddate: "",
-            playtime: 0
+            playtime: 0,
+            hdr: ""
         )
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Core/Network/Foundation/BaseURLConstants.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/Foundation/BaseURLConstants.swift
@@ -15,6 +15,6 @@ enum BaseURLConstants {
         "\(scheme)://\(cameraIP):\(port)/ccapi/"
     }
     static var baseArchiveURL: String {
-        "\(scheme)://\(cameraIP):\(port)/"
+        "\(scheme)://\(cameraIP):\(port)"
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Core/Network/Foundation/BaseURLConstants.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Network/Foundation/BaseURLConstants.swift
@@ -14,4 +14,7 @@ enum BaseURLConstants {
     static var baseURL: String {
         "\(scheme)://\(cameraIP):\(port)/ccapi/"
     }
+    static var baseArchiveURL: String {
+        "\(scheme)://\(cameraIP):\(port)/"
+    }
 }

--- a/HonestHouse/HonestHouse/Sources/Extension/DateFormatter+Extension.swift
+++ b/HonestHouse/HonestHouse/Sources/Extension/DateFormatter+Extension.swift
@@ -23,6 +23,15 @@ extension DateFormatter {
         return formatter
     }()
     
+    /// API lastmodifieddate 파싱용 (타임존 없는 버전): "Tue, 11 Nov 2025 21:02:28"
+    static let apiDateFormatterWithoutTimezone: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(abbreviation: "GMT")
+        return formatter
+    }()
+    
     /// 날짜 키 생성용: "yyyy-MM-dd"
     static let dateKeyFormatter: DateFormatter = {
         let formatter = DateFormatter()

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/ViewModel/PhotoSelectionViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/ViewModel/PhotoSelectionViewModel.swift
@@ -104,7 +104,7 @@ final class PhotoSelectionViewModel {
         presentStorage = storageName
     }
     
-    /// directoryList에서 첫번째 directory가져오기
+    /// directoryList에서 첫번째 directory가져오기 (ver110, ver120)
     func setPresentDirectory(storage: String) async throws {
         try await getDirectoryList(storage: storage)
         guard
@@ -114,6 +114,23 @@ final class PhotoSelectionViewModel {
             throw ArchiveError.photoLoadingFailed
         }
         presentDirectory = dirName
+    }
+    
+    /// directoryList에서 첫번째 directory가져오기 (ver140)
+    func setPresentDirectoryV140(storage: String) async throws {
+        try await getDirectoryList(storage: storage)
+        
+        guard let dirUrl = directoryList?.url?.first else {
+            throw ArchiveError.photoLoadingFailed
+        }
+        
+        let components = dirUrl.split(separator: "/")
+        
+        guard components.count >= 2 else {
+            throw ArchiveError.photoLoadingFailed
+        }
+        
+        presentDirectory = components.suffix(2).joined(separator: "/")
     }
     
     /// 새 Chunk 처리: Info 먼저 가져온 후 섹션 구성
@@ -171,13 +188,13 @@ final class PhotoSelectionViewModel {
                         )
                         
                         return Photo(
-                            url: url,
+                            url: BaseURLConstants.baseArchiveURL + url,
                             dateInfo: contentInfo.dateInfo
                         )
                     } catch {
                         print("ContentInfo 가져오기 실패: \(url), \(error)")
                         // 실패한 경우 날짜 없이 Photo 생성
-                        return Photo(url: url, dateInfo: nil)
+                        return Photo(url: BaseURLConstants.baseArchiveURL + url, dateInfo: nil)
                     }
                 }
             }
@@ -262,8 +279,19 @@ final class PhotoSelectionViewModel {
             try await setPresentStorage()
             guard let storage = presentStorage else { throw ArchiveError.photoLoadingFailed }
             
+            guard let cameraType = CameraType.current else {
+                throw ArchiveError.photoLoadingFailed
+            }
+            
             // 2. Directory 설정
-            try await setPresentDirectory(storage: storage)
+            switch cameraType.imageOperationsVersion {
+            case .ver110, .ver120:
+                try await setPresentDirectory(storage: storage)
+            case .ver140:
+                try await setPresentDirectoryV140(storage: storage)
+            default:
+                throw ArchiveError.photoLoadingFailed
+            }
             guard let directory = presentDirectory else { throw ArchiveError.photoLoadingFailed }
             
             // 3. Content List 가져오기 (점진적 로딩)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Main/ViewModel/MainViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Main/ViewModel/MainViewModel.swift
@@ -164,55 +164,55 @@ final class MainViewModel {
 
     private func ignoreShootingMode(action: String) async throws {
         let request = ShootingControl.IgnoreShootingModeRequest(action: action)
-        try await container.services.shootingControlService.ignoreShootingMode(with: .ver100, request: request)
+        try await container.services.shootingControlService.ignoreShootingMode(request: request)
     }
 
     private func setShootingMode(value: String) async throws {
         let request = ShootingSettings.ShootingModeRequest(value: value)
-        _ = try await container.services.shootingSettingsService.putShootingMode(with: .ver100, request: request)
-        let response = try await container.services.shootingSettingsService.putShootingMode(with: .ver110, request: request)
+        _ = try await container.services.shootingSettingsService.putShootingMode(request: request)
+        let response = try await container.services.shootingSettingsService.putShootingMode(request: request)
         Logger.debug("Shooting Mode Response: \(response)", category: .viewModel)
     }
 
     private func setPictureStyle(value: String) async throws {
         let request = ShootingSettings.PictureStyleRequest(value: value)
-        let response = try await container.services.shootingSettingsService.putPictureStyle(with: .ver100, request: request)
+        let response = try await container.services.shootingSettingsService.putPictureStyle(request: request)
         Logger.debug("Picture Style Response: \(response)", category: .viewModel)
     }
 
     private func setAperture(value: String) async throws {
         let request = ShootingSettings.AVRequest(value: value)
-        let response = try await container.services.shootingSettingsService.putAV(with: .ver100, request: request)
+        let response = try await container.services.shootingSettingsService.putAV(request: request)
         Logger.debug("Aperture Response: \(response)", category: .viewModel)
     }
 
     private func setShutterSpeed(value: String) async throws {
         let request = ShootingSettings.TVRequest(value: value)
-        _ = try await container.services.shootingSettingsService.putTV(with: .ver100, request: request)
+        _ = try await container.services.shootingSettingsService.putTV(request: request)
     }
 
     private func setISO(value: String) async throws {
         let request = ShootingSettings.ISORequest(value: value)
-        let response = try await container.services.shootingSettingsService.putISO(with: .ver100, request: request)
+        let response = try await container.services.shootingSettingsService.putISO(request: request)
         Logger.debug("ISO Response: \(response)", category: .viewModel)
     }
 
     private func setExposureCompensation(value: String) async throws {
         let request = ShootingSettings.ExposureCompensationRequest(value: value)
-        let response = try await container.services.shootingSettingsService.putExposureCompensation(with: .ver100, request: request)
+        let response = try await container.services.shootingSettingsService.putExposureCompensation(request: request)
         Logger.debug("Exposure Compensation Response: \(response)", category: .viewModel)
     }
 
     private func setColorTemperature(value: Int) async throws {
         let request = ShootingSettings.ColorTemperatureRequest(value: value)
-        let response = try await container.services.shootingSettingsService.putColorTemperature(with: .ver100, request: request)
+        let response = try await container.services.shootingSettingsService.putColorTemperature(request: request)
         Logger.debug("Color Temperature Response: \(response)", category: .viewModel)
     }
 
     private func setWbShift(blueAmber: Int, magentaGreen: Int) async throws {
         let wbShift = ShootingSettings.WBShiftRequest.WBShift(blueAmber: blueAmber, magentaGreen: magentaGreen)
         let request = ShootingSettings.WBShiftRequest(value: wbShift)
-        let response = try await container.services.shootingSettingsService.putWbShift(with: .ver100, request: request)
+        let response = try await container.services.shootingSettingsService.putWbShift(request: request)
         Logger.debug("WB Shift Response: \(response)", category: .viewModel)
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Trishot/ViewModel/TrishotActivationViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Trishot/ViewModel/TrishotActivationViewModel.swift
@@ -186,7 +186,7 @@ extension TrishotActivationViewModel {
     private func ignoreShootingMode(action: String) async throws {
         do {
             let request = ShootingControl.IgnoreShootingModeRequest(action: action)
-            try await container.services.shootingControlService.ignoreShootingMode(with: .ver100, request: request)
+            try await container.services.shootingControlService.ignoreShootingMode(request: request)
         } catch let ccapiError as CCAPIError {
             throw TrishotError.from(ccapiError: ccapiError)
         } catch {
@@ -197,8 +197,7 @@ extension TrishotActivationViewModel {
     private func setShootingMode(value: String) async throws {
         do {
             let request = ShootingSettings.ShootingModeRequest(value: value)
-            // MARK: R50V 기준 ver110 사용.
-            _ = try await container.services.shootingSettingsService.putShootingMode(with: .ver110, request: request)
+            _ = try await container.services.shootingSettingsService.putShootingMode(request: request)
         } catch let ccapiError as CCAPIError {
             throw TrishotError.from(ccapiError: ccapiError)
         } catch {
@@ -209,7 +208,7 @@ extension TrishotActivationViewModel {
     private func setPictureStyle(value: String) async throws {
         do {
             let request = ShootingSettings.PictureStyleRequest(value: value)
-            _ = try await container.services.shootingSettingsService.putPictureStyle(with: .ver100, request: request)
+            _ = try await container.services.shootingSettingsService.putPictureStyle(request: request)
         } catch let ccapiError as CCAPIError {
             throw TrishotError.from(ccapiError: ccapiError)
         } catch {
@@ -220,7 +219,7 @@ extension TrishotActivationViewModel {
     private func setAperture(value: String) async throws {
         do {
             let request = ShootingSettings.AVRequest(value: value)
-            _ = try await container.services.shootingSettingsService.putAV(with: .ver100, request: request)
+            _ = try await container.services.shootingSettingsService.putAV(request: request)
         } catch let ccapiError as CCAPIError {
             throw TrishotError.from(ccapiError: ccapiError)
         } catch {
@@ -231,7 +230,7 @@ extension TrishotActivationViewModel {
     private func setShutterSpeed(value: String) async throws {
         do {
             let request = ShootingSettings.TVRequest(value: value)
-            _ = try await container.services.shootingSettingsService.putTV(with: .ver100, request: request)
+            _ = try await container.services.shootingSettingsService.putTV(request: request)
         } catch let ccapiError as CCAPIError {
             throw TrishotError.from(ccapiError: ccapiError)
         } catch {
@@ -242,7 +241,7 @@ extension TrishotActivationViewModel {
     private func setISO(value: String) async throws {
         do {
             let request = ShootingSettings.ISORequest(value: value)
-            _ = try await container.services.shootingSettingsService.putISO(with: .ver100, request: request)
+            _ = try await container.services.shootingSettingsService.putISO(request: request)
         } catch let ccapiError as CCAPIError {
             throw TrishotError.from(ccapiError: ccapiError)
         } catch {
@@ -253,7 +252,7 @@ extension TrishotActivationViewModel {
     private func setExposureCompensation(value: String) async throws {
         do {
             let request = ShootingSettings.ExposureCompensationRequest(value: value)
-            _ = try await container.services.shootingSettingsService.putExposureCompensation(with: .ver100, request: request)
+            _ = try await container.services.shootingSettingsService.putExposureCompensation(request: request)
         } catch let ccapiError as CCAPIError {
             throw TrishotError.from(ccapiError: ccapiError)
         } catch {
@@ -264,7 +263,7 @@ extension TrishotActivationViewModel {
     private func setColorTemperature(value: Int) async throws {
         do {
             let request = ShootingSettings.ColorTemperatureRequest(value: value)
-            _ = try await container.services.shootingSettingsService.putColorTemperature(with: .ver100, request: request)
+            _ = try await container.services.shootingSettingsService.putColorTemperature(request: request)
         } catch let ccapiError as CCAPIError {
             throw TrishotError.from(ccapiError: ccapiError)
         } catch {
@@ -276,7 +275,7 @@ extension TrishotActivationViewModel {
         do {
             let wbShift = ShootingSettings.WBShiftRequest.WBShift(blueAmber: blueAmber, magentaGreen: magentaGreen)
             let request = ShootingSettings.WBShiftRequest(value: wbShift)
-            _ = try await container.services.shootingSettingsService.putWbShift(with: .ver100, request: request)
+            _ = try await container.services.shootingSettingsService.putWbShift(request: request)
         } catch let ccapiError as CCAPIError {
             throw TrishotError.from(ccapiError: ccapiError)
         } catch {
@@ -286,12 +285,12 @@ extension TrishotActivationViewModel {
     
     /// Ability Information 가져오기, 확인용
     private func getAbilityInformation() async throws {
-        let r1 = try await container.services.shootingSettingsService.getAV(with: .ver100)
-        let r2 = try await container.services.shootingSettingsService.getTV(with: .ver100)
-        let r3 = try await container.services.shootingSettingsService.getISO(with: .ver100)
-        let r4 = try await container.services.shootingSettingsService.getExposureCompensation(with: .ver100)
-        let r5 = try await container.services.shootingSettingsService.getColorTemperature(with: .ver100)
-        let r6 = try await container.services.shootingSettingsService.getWbShift(with: .ver100)
+        let r1 = try await container.services.shootingSettingsService.getAV()
+        let r2 = try await container.services.shootingSettingsService.getTV()
+        let r3 = try await container.services.shootingSettingsService.getISO()
+        let r4 = try await container.services.shootingSettingsService.getExposureCompensation()
+        let r5 = try await container.services.shootingSettingsService.getColorTemperature()
+        let r6 = try await container.services.shootingSettingsService.getWbShift()
         
         print(r1)
         print(r2)

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.7. ImageOperationsService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.7. ImageOperationsService.swift
@@ -95,8 +95,9 @@ final class ImageOperationsService: BaseService, ImageOperationsServiceType {
         kind: String,
         order: String
     ) throws -> URL {
-        let urlString = "\(BaseURLConstants.baseURL)ver100/contents/\(storage)/\(directory)?type=\(type)&kind=\(kind)&order=\(order)"
-        
+        let version = CameraType.current?.imageOperationsVersion ?? .ver100
+        let urlString = "\(BaseURLConstants.baseURL)\(version.description)/contents/\(storage)/\(directory)?type=\(type)&kind=\(kind)&order=\(order)"
+
         guard let url = URL(string: urlString) else {
             throw CCAPIError.invalidURL
         }

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.7. ImageOperationsService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.7. ImageOperationsService.swift
@@ -84,8 +84,8 @@ final class ImageOperationsService: BaseService, ImageOperationsServiceType {
     }
     
     private static func mergeResponses(_ responses: [ImageOperations.ContentListResponse]) -> ImageOperations.ContentListResponse {
-        let allUrls = responses.flatMap { $0.url ?? [] }
-        return ImageOperations.ContentListResponse(url: allUrls)
+        let allUrls = responses.flatMap { $0.path ?? [] }
+        return ImageOperations.ContentListResponse(path: allUrls)
     }
     
     private func buildContentListURL(
@@ -96,7 +96,7 @@ final class ImageOperationsService: BaseService, ImageOperationsServiceType {
         order: String
     ) throws -> URL {
         let version = CameraType.current?.imageOperationsVersion ?? .ver100
-        let urlString = "\(BaseURLConstants.baseURL)\(version.description)/contents/\(storage)/\(directory)?type=\(type)&kind=\(kind)&order=\(order)"
+        let urlString = "\(BaseURLConstants.baseArchiveURL)\(version.description)/contents/\(storage)/\(directory)?type=\(type)&kind=\(kind)&order=\(order)"
 
         guard let url = URL(string: urlString) else {
             throw CCAPIError.invalidURL

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.8. ShootingControlService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.8. ShootingControlService.swift
@@ -8,16 +8,16 @@
 import Foundation
 
 protocol ShootingControlServiceType {
-    func ignoreShootingMode(with: VersionType, request: ShootingControl.IgnoreShootingModeRequest) async throws
+    func ignoreShootingMode(request: ShootingControl.IgnoreShootingModeRequest) async throws
 }
 
 final class ShootingControlService: BaseService, ShootingControlServiceType {
-    func ignoreShootingMode(with version: VersionType, request: ShootingControl.IgnoreShootingModeRequest) async throws {
+    func ignoreShootingMode(request: ShootingControl.IgnoreShootingModeRequest) async throws {
         try await self.request(ShootingControlTarget.ignoreShootingMode(request))
     }
 }
 
 final class StubShootingControlService: ShootingControlServiceType {
-    func ignoreShootingMode(with: VersionType, request: ShootingControl.IgnoreShootingModeRequest) async throws {
+    func ignoreShootingMode(request: ShootingControl.IgnoreShootingModeRequest) async throws {
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.9. ShootingSettingsService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/4.9. ShootingSettingsService.swift
@@ -9,219 +9,216 @@ import Foundation
 
 protocol ShootingSettingsServiceType {
     /// 촬영 모드
-    func getShootingMode(with: VersionType) async throws -> ShootingSettings.ShootingModeResponse
-    func putShootingMode(with: VersionType, request: ShootingSettings.ShootingModeRequest) async throws -> ShootingSettings.ShootingModeResponse
-    func getShootingModeDial(with: VersionType) async throws -> ShootingSettings.ShootingModeResponse
-    func putShootingModeDial(with: VersionType, request: ShootingSettings.ShootingModeRequest) async throws -> ShootingSettings.ShootingModeResponse
+    func getShootingMode() async throws -> ShootingSettings.ShootingModeResponse
+    func putShootingMode(request: ShootingSettings.ShootingModeRequest) async throws -> ShootingSettings.ShootingModeResponse
+    func getShootingModeDial() async throws -> ShootingSettings.ShootingModeResponse
+    func putShootingModeDial(request: ShootingSettings.ShootingModeRequest) async throws -> ShootingSettings.ShootingModeResponse
     /// 조리개
-    func getAV(with: VersionType) async throws -> ShootingSettings.AVResponse
-    func putAV(with: VersionType, request: ShootingSettings.AVRequest) async throws -> ShootingSettings.AVResponse
+    func getAV() async throws -> ShootingSettings.AVResponse
+    func putAV(request: ShootingSettings.AVRequest) async throws -> ShootingSettings.AVResponse
     /// 셔터스피드
-    func getTV(with: VersionType) async throws -> ShootingSettings.TVResponse
-    func putTV(with: VersionType, request: ShootingSettings.TVRequest) async throws -> ShootingSettings.TVResponse
+    func getTV() async throws -> ShootingSettings.TVResponse
+    func putTV(request: ShootingSettings.TVRequest) async throws -> ShootingSettings.TVResponse
     /// ISO
-    func getISO(with: VersionType) async throws -> ShootingSettings.ISOResponse
-    func putISO(with: VersionType, request: ShootingSettings.ISORequest) async throws -> ShootingSettings.ISOResponse
+    func getISO() async throws -> ShootingSettings.ISOResponse
+    func putISO(request: ShootingSettings.ISORequest) async throws -> ShootingSettings.ISOResponse
     /// 노출 보정
-    func getExposureCompensation(with: VersionType) async throws -> ShootingSettings.ExposureCompensationResponse
-    func putExposureCompensation(with: VersionType, request: ShootingSettings.ExposureCompensationRequest) async throws -> ShootingSettings.ExposureCompensationResponse
+    func getExposureCompensation() async throws -> ShootingSettings.ExposureCompensationResponse
+    func putExposureCompensation(request: ShootingSettings.ExposureCompensationRequest) async throws -> ShootingSettings.ExposureCompensationResponse
     /// 화이트 밸런스
-    func getWhiteBalance(with: VersionType) async throws -> ShootingSettings.WhiteBalanceResponse
-    func putWhiteBalance(with: VersionType, request: ShootingSettings.WhiteBalanceRequest) async throws -> ShootingSettings.WhiteBalanceResponse
+    func getWhiteBalance() async throws -> ShootingSettings.WhiteBalanceResponse
+    func putWhiteBalance(request: ShootingSettings.WhiteBalanceRequest) async throws -> ShootingSettings.WhiteBalanceResponse
     /// 색온도
-    func getColorTemperature(with: VersionType) async throws -> ShootingSettings.ColorTemperatureResponse
-    func putColorTemperature(with: VersionType, request: ShootingSettings.ColorTemperatureRequest) async throws -> ShootingSettings.ColorTemperatureResponse
+    func getColorTemperature() async throws -> ShootingSettings.ColorTemperatureResponse
+    func putColorTemperature(request: ShootingSettings.ColorTemperatureRequest) async throws -> ShootingSettings.ColorTemperatureResponse
     /// 화이트 밸런스 쉬프트(틴트)
-    func getWbShift(with: VersionType) async throws -> ShootingSettings.WBShiftResponse
-    func putWbShift(with: VersionType, request: ShootingSettings.WBShiftRequest) async throws -> ShootingSettings.WBShiftResponse
+    func getWbShift() async throws -> ShootingSettings.WBShiftResponse
+    func putWbShift(request: ShootingSettings.WBShiftRequest) async throws -> ShootingSettings.WBShiftResponse
     /// 픽쳐스타일
-    func getPictureStyle(with: VersionType) async throws -> ShootingSettings.PictureStyleResponse
-    func putPictureStyle(with: VersionType, request: ShootingSettings.PictureStyleRequest) async throws -> ShootingSettings.PictureStyleResponse
+    func getPictureStyle() async throws -> ShootingSettings.PictureStyleResponse
+    func putPictureStyle(request: ShootingSettings.PictureStyleRequest) async throws -> ShootingSettings.PictureStyleResponse
 }
 
 final class ShootingSettingsService: BaseService, ShootingSettingsServiceType {
-    func getShootingMode(with version: VersionType) async throws -> ShootingSettings.ShootingModeResponse {
+    func getShootingMode() async throws -> ShootingSettings.ShootingModeResponse {
         let response = try await request(ShootingSettingsTarget.getShootingMode, decoding: ShootingSettings.ShootingModeResponse.self)
-        
         return response
     }
-
-    func putShootingMode(with version: VersionType, request: ShootingSettings.ShootingModeRequest) async throws -> ShootingSettings.ShootingModeResponse {
+    
+    func putShootingMode(request: ShootingSettings.ShootingModeRequest) async throws -> ShootingSettings.ShootingModeResponse {
         let response = try await self.request(ShootingSettingsTarget.putShootingMode(request), decoding: ShootingSettings.ShootingModeResponse.self)
         return response
     }
     
-    func getShootingModeDial(with: VersionType) async throws -> ShootingSettings.ShootingModeResponse {
-        let response = try await request(ShootingSettingsTarget.getShootingModeDial, decoding: ShootingSettings.ShootingModeResponse.self)
+    func getShootingModeDial() async throws -> ShootingSettings.ShootingModeResponse {
+        let response = try await request(ShootingSettingsTarget.getShootingMode, decoding: ShootingSettings.ShootingModeResponse.self)
         return response
     }
     
-    func putShootingModeDial(with: VersionType, request: ShootingSettings.ShootingModeRequest) async throws -> ShootingSettings.ShootingModeResponse {
-        let response = try await self.request(ShootingSettingsTarget.putShootingModeDial(request), decoding: ShootingSettings.ShootingModeResponse.self)
+    func putShootingModeDial(request: ShootingSettings.ShootingModeRequest) async throws -> ShootingSettings.ShootingModeResponse {
+        let response = try await self.request(ShootingSettingsTarget.putShootingMode(request), decoding: ShootingSettings.ShootingModeResponse.self)
         return response
     }
-
-    func getAV(with version: VersionType) async throws -> ShootingSettings.AVResponse {
+    
+    func getAV() async throws -> ShootingSettings.AVResponse {
         let response = try await request(ShootingSettingsTarget.getAv, decoding: ShootingSettings.AVResponse.self)
         return response
     }
 
-    func putAV(with version: VersionType, request: ShootingSettings.AVRequest) async throws -> ShootingSettings.AVResponse {
+    func putAV(request: ShootingSettings.AVRequest) async throws -> ShootingSettings.AVResponse {
         let response = try await self.request(ShootingSettingsTarget.putAv(request), decoding: ShootingSettings.AVResponse.self)
         return response
     }
 
-    func getTV(with version: VersionType) async throws -> ShootingSettings.TVResponse {
+    func getTV() async throws -> ShootingSettings.TVResponse {
         let response = try await request(ShootingSettingsTarget.getTv, decoding: ShootingSettings.TVResponse.self)
         return response
     }
 
-    func putTV(with version: VersionType, request: ShootingSettings.TVRequest) async throws -> ShootingSettings.TVResponse {
+    func putTV(request: ShootingSettings.TVRequest) async throws -> ShootingSettings.TVResponse {
         let response = try await self.request(ShootingSettingsTarget.putTv(request), decoding: ShootingSettings.TVResponse.self)
         return response
     }
 
-    func getISO(with version: VersionType) async throws -> ShootingSettings.ISOResponse {
+    func getISO() async throws -> ShootingSettings.ISOResponse {
         let response = try await request(ShootingSettingsTarget.getIso, decoding: ShootingSettings.ISOResponse.self)
         return response
     }
 
-    func putISO(with version: VersionType, request: ShootingSettings.ISORequest) async throws -> ShootingSettings.ISOResponse {
+    func putISO(request: ShootingSettings.ISORequest) async throws -> ShootingSettings.ISOResponse {
         let response = try await self.request(ShootingSettingsTarget.putIso(request), decoding: ShootingSettings.ISOResponse.self)
         return response
     }
 
-    func getExposureCompensation(with version: VersionType) async throws -> ShootingSettings.ExposureCompensationResponse {
+    func getExposureCompensation() async throws -> ShootingSettings.ExposureCompensationResponse {
         let response = try await request(ShootingSettingsTarget.getExposureCompensation, decoding: ShootingSettings.ExposureCompensationResponse.self)
         return response
     }
 
-    func putExposureCompensation(with version: VersionType, request: ShootingSettings.ExposureCompensationRequest) async throws -> ShootingSettings.ExposureCompensationResponse {
+    func putExposureCompensation(request: ShootingSettings.ExposureCompensationRequest) async throws -> ShootingSettings.ExposureCompensationResponse {
         let response = try await self.request(ShootingSettingsTarget.putExposureCompensation(request), decoding: ShootingSettings.ExposureCompensationResponse.self)
         return response
     }
 
-    func getWhiteBalance(with version: VersionType) async throws -> ShootingSettings.WhiteBalanceResponse {
+    func getWhiteBalance() async throws -> ShootingSettings.WhiteBalanceResponse {
         let response = try await request(ShootingSettingsTarget.getWhiteBalance, decoding: ShootingSettings.WhiteBalanceResponse.self)
         return response
     }
 
-    func putWhiteBalance(with version: VersionType, request: ShootingSettings.WhiteBalanceRequest) async throws -> ShootingSettings.WhiteBalanceResponse {
+    func putWhiteBalance(request: ShootingSettings.WhiteBalanceRequest) async throws -> ShootingSettings.WhiteBalanceResponse {
         let response = try await self.request(ShootingSettingsTarget.putWhiteBalance(request), decoding: ShootingSettings.WhiteBalanceResponse.self)
         return response
     }
 
-    func getColorTemperature(with version: VersionType) async throws -> ShootingSettings.ColorTemperatureResponse {
+    func getColorTemperature() async throws -> ShootingSettings.ColorTemperatureResponse {
         let response = try await request(ShootingSettingsTarget.getColorTemperature, decoding: ShootingSettings.ColorTemperatureResponse.self)
         return response
     }
 
-    func putColorTemperature(with version: VersionType, request: ShootingSettings.ColorTemperatureRequest) async throws -> ShootingSettings.ColorTemperatureResponse {
+    func putColorTemperature(request: ShootingSettings.ColorTemperatureRequest) async throws -> ShootingSettings.ColorTemperatureResponse {
         let response = try await self.request(ShootingSettingsTarget.putColorTemperature(request), decoding: ShootingSettings.ColorTemperatureResponse.self)
         return response
     }
 
-    func getWbShift(with version: VersionType) async throws -> ShootingSettings.WBShiftResponse {
+    func getWbShift() async throws -> ShootingSettings.WBShiftResponse {
         let response = try await request(ShootingSettingsTarget.getWbShift, decoding: ShootingSettings.WBShiftResponse.self)
         return response
     }
 
-    func putWbShift(with version: VersionType, request: ShootingSettings.WBShiftRequest) async throws -> ShootingSettings.WBShiftResponse {
+    func putWbShift(request: ShootingSettings.WBShiftRequest) async throws -> ShootingSettings.WBShiftResponse {
         let response = try await self.request(ShootingSettingsTarget.putWbShift(request), decoding: ShootingSettings.WBShiftResponse.self)
         return response
     }
 
-    func getPictureStyle(with version: VersionType) async throws -> ShootingSettings.PictureStyleResponse {
+    func getPictureStyle() async throws -> ShootingSettings.PictureStyleResponse {
         let response = try await request(ShootingSettingsTarget.getPictureStyle, decoding: ShootingSettings.PictureStyleResponse.self)
         return response
     }
 
-    func putPictureStyle(with version: VersionType, request: ShootingSettings.PictureStyleRequest) async throws -> ShootingSettings.PictureStyleResponse {
+    func putPictureStyle(request: ShootingSettings.PictureStyleRequest) async throws -> ShootingSettings.PictureStyleResponse {
         let response = try await self.request(ShootingSettingsTarget.putPictureStyle(request), decoding: ShootingSettings.PictureStyleResponse.self)
         return response
     }
 }
 
-// MARK: - StubShootingSettingsService
-
 class StubShootingSettingsService: ShootingSettingsServiceType {
-    func putShootingMode(with: VersionType, request: ShootingSettings.ShootingModeRequest) async throws -> ShootingSettings.ShootingModeResponse {
+    func putShootingMode(request: ShootingSettings.ShootingModeRequest) async throws -> ShootingSettings.ShootingModeResponse {
         return .stub1
     }
     
-    func getShootingModeDial(with: VersionType) async throws -> ShootingSettings.ShootingModeResponse {
+    func getShootingModeDial() async throws -> ShootingSettings.ShootingModeResponse {
         return .stub1
     }
     
-    func putShootingModeDial(with: VersionType, request: ShootingSettings.ShootingModeRequest) async throws -> ShootingSettings.ShootingModeResponse {
+    func putShootingModeDial(request: ShootingSettings.ShootingModeRequest) async throws -> ShootingSettings.ShootingModeResponse {
         return .stub1
     }
     
-    func getAV(with: VersionType) async throws -> ShootingSettings.AVResponse {
+    func getAV() async throws -> ShootingSettings.AVResponse {
         return .stub1
     }
     
-    func putAV(with: VersionType, request: ShootingSettings.AVRequest) async throws -> ShootingSettings.AVResponse {
+    func putAV(request: ShootingSettings.AVRequest) async throws -> ShootingSettings.AVResponse {
         return .stub1
     }
     
-    func getTV(with: VersionType) async throws -> ShootingSettings.TVResponse {
+    func getTV() async throws -> ShootingSettings.TVResponse {
         return .stub1
     }
     
-    func putTV(with: VersionType, request: ShootingSettings.TVRequest) async throws -> ShootingSettings.TVResponse {
+    func putTV(request: ShootingSettings.TVRequest) async throws -> ShootingSettings.TVResponse {
         return .stub1
     }
     
-    func getISO(with: VersionType) async throws -> ShootingSettings.ISOResponse {
+    func getISO() async throws -> ShootingSettings.ISOResponse {
         return .stub1
     }
     
-    func putISO(with: VersionType, request: ShootingSettings.ISORequest) async throws -> ShootingSettings.ISOResponse {
+    func putISO(request: ShootingSettings.ISORequest) async throws -> ShootingSettings.ISOResponse {
         return .stub1
     }
     
-    func getExposureCompensation(with: VersionType) async throws -> ShootingSettings.ExposureCompensationResponse {
+    func getExposureCompensation() async throws -> ShootingSettings.ExposureCompensationResponse {
+        return .stub1
+    }
+
+    func putExposureCompensation(request: ShootingSettings.ExposureCompensationRequest) async throws -> ShootingSettings.ExposureCompensationResponse {
         return .stub1
     }
     
-    func putExposureCompensation(with: VersionType, request: ShootingSettings.ExposureCompensationRequest) async throws -> ShootingSettings.ExposureCompensationResponse {
+    func getWhiteBalance() async throws -> ShootingSettings.WhiteBalanceResponse {
         return .stub1
     }
     
-    func getWhiteBalance(with: VersionType) async throws -> ShootingSettings.WhiteBalanceResponse {
+    func putWhiteBalance(request: ShootingSettings.WhiteBalanceRequest) async throws -> ShootingSettings.WhiteBalanceResponse {
         return .stub1
     }
     
-    func putWhiteBalance(with: VersionType, request: ShootingSettings.WhiteBalanceRequest) async throws -> ShootingSettings.WhiteBalanceResponse {
+    func getColorTemperature() async throws -> ShootingSettings.ColorTemperatureResponse {
         return .stub1
     }
     
-    func getColorTemperature(with: VersionType) async throws -> ShootingSettings.ColorTemperatureResponse {
+    func putColorTemperature(request: ShootingSettings.ColorTemperatureRequest) async throws -> ShootingSettings.ColorTemperatureResponse {
         return .stub1
     }
     
-    func putColorTemperature(with: VersionType, request: ShootingSettings.ColorTemperatureRequest) async throws -> ShootingSettings.ColorTemperatureResponse {
+    func getWbShift() async throws -> ShootingSettings.WBShiftResponse {
         return .stub1
     }
     
-    func getWbShift(with: VersionType) async throws -> ShootingSettings.WBShiftResponse {
+    func putWbShift(request: ShootingSettings.WBShiftRequest) async throws -> ShootingSettings.WBShiftResponse {
         return .stub1
     }
     
-    func putWbShift(with: VersionType, request: ShootingSettings.WBShiftRequest) async throws -> ShootingSettings.WBShiftResponse {
+    func putPictureStyle(request: ShootingSettings.PictureStyleRequest) async throws -> ShootingSettings.PictureStyleResponse {
         return .stub1
     }
     
-    func putPictureStyle(with: VersionType, request: ShootingSettings.PictureStyleRequest) async throws -> ShootingSettings.PictureStyleResponse {
+    func getShootingMode() async throws -> ShootingSettings.ShootingModeResponse {
         return .stub1
     }
     
-    func getShootingMode(with: VersionType) async throws -> ShootingSettings.ShootingModeResponse {
-        return .stub1
-    }
-    
-    func getPictureStyle(with: VersionType) async throws -> ShootingSettings.PictureStyleResponse {
+    func getPictureStyle() async throws -> ShootingSettings.PictureStyleResponse {
         return .stub1
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Service/CCAPI/EventMonitor/EventMonitorService.swift
+++ b/HonestHouse/HonestHouse/Sources/Service/CCAPI/EventMonitor/EventMonitorService.swift
@@ -25,7 +25,12 @@ final class EventMonitorService: StreamService, EventMonitorServiceType {
     }
 
     override var endpoint: String {
-        return "ver100/event/monitoring"
+        guard let cameraType = CameraType.current else {
+            return "ver100/event/monitoring"
+        }
+
+        let version = cameraType.eventMonitorVersion
+        return "\(version.description)/event/monitoring"
     }
 
     override var httpMethod: String {

--- a/HonestHouse/HonestHouse/Sources/Type/CameraType.swift
+++ b/HonestHouse/HonestHouse/Sources/Type/CameraType.swift
@@ -8,17 +8,11 @@
 import Foundation
 
 enum CameraType: String, CaseIterable {
-    case eos1DXMarkIII = "Canon EOS-1D X Mark III"
-    case eosR5 = "Canon EOS R5"
     case eosR6 = "Canon EOS R6"
-    case eosR3 = "Canon EOS R3"
     case eosR7 = "Canon EOS R7"
     case eosR6MarkII = "Canon EOS R6 Mark II"
     case eosR8 = "Canon EOS R8"
     case eosR50 = "Canon EOS R50"
-    case powerShotV10 = "Canon PowerShot V10"
-    case eosR5MARKII = "Canon EOS R5 Mark II"
-    case eosR1 = "EOS R1"
     case eosR50V = "Canon EOS R50 V"
         
     var displayName: String {
@@ -52,9 +46,9 @@ enum CameraType: String, CaseIterable {
     /// 모드 다이얼 유무
     var hasShootingModeDial: Bool {
         switch self {
-        case .eosR50, .eosR6MarkII, .eosR6, .eosR8:
+        case .eosR50, .eosR6MarkII, .eosR6, .eosR8, .eosR7:
             return true
-        case .eosR50V, .eosR1, .eosR5MARKII, .powerShotV10, .eosR7, .eosR3, .eosR5, .eos1DXMarkIII:
+        case .eosR50V:
             return false
         }
     }
@@ -62,11 +56,11 @@ enum CameraType: String, CaseIterable {
     /// Image Operations API 버전
     var imageOperationsVersion: VersionType {
         switch self {
-        case .eos1DXMarkIII, .eosR5, .eosR6, .eosR3, .eosR7:
+        case .eosR6, .eosR7:
             return .ver110
-        case .eosR50, .eosR6MarkII, .eosR8, .powerShotV10:
+        case .eosR50, .eosR6MarkII, .eosR8:
             return .ver120
-        case .eosR50V, .eosR5MARKII, .eosR1:
+        case .eosR50V:
             return .ver140
         }
     }
@@ -74,7 +68,7 @@ enum CameraType: String, CaseIterable {
     /// Event Monitor API 버전
     var eventMonitorVersion: VersionType {
         switch self {
-        case .eos1DXMarkIII, .eosR1, .eosR5, .eosR6, .eosR3, .eosR7, .eosR8, .eosR50, .powerShotV10, .eosR5MARKII, .eosR6MarkII, .eosR50V:
+        case .eosR6, .eosR7, .eosR8, .eosR50, .eosR6MarkII, .eosR50V:
             return .ver100
         }
     }
@@ -82,7 +76,7 @@ enum CameraType: String, CaseIterable {
     /// Shooting Control API 버전
     var shootingControlVersion: VersionType {
         switch self {
-        case .eos1DXMarkIII, .eosR1, .eosR5, .eosR6, .eosR3, .eosR7, .eosR8, .powerShotV10, .eosR5MARKII, .eosR50, .eosR6MarkII, .eosR50V:
+        case .eosR6, .eosR7, .eosR8, .eosR50, .eosR6MarkII, .eosR50V:
             return .ver100
         }
     }

--- a/HonestHouse/HonestHouse/Sources/Type/CameraType.swift
+++ b/HonestHouse/HonestHouse/Sources/Type/CameraType.swift
@@ -8,9 +8,18 @@
 import Foundation
 
 enum CameraType: String, CaseIterable {
-    case eosR50 = "EOS R50"
-    case eosR50V = "EOS R50V"
+    case eos1DXMarkIII = "EOS-1D X Mark III"
+    case eosR5 = "EOS R5"
+    case eosR6 = "EOS R6"
+    case eosR3 = "EOS R3"
+    case eosR7 = "EOS R7"
     case eosR6MarkII = "EOS R6 Mark II"
+    case eosR8 = "EOS R8"
+    case eosR50 = "EOS R50"
+    case powerShotV10 = "PowerShot V10"
+    case eosR5MARKII = "EOS R5 Mark II"
+    case eosR1 = "EOS R1"
+    case eosR50V = "EOS R50V"
         
     var displayName: String {
         return rawValue
@@ -43,7 +52,7 @@ enum CameraType: String, CaseIterable {
     /// 모드 다이얼 유무
     var hasShootingModeDial: Bool {
         switch self {
-        case .eosR50, .eosR6MarkII:
+        case .eosR50, .eosR6MarkII, .eos1DXMarkIII, .eosR5, .eosR6, .eosR3, .eosR7, .eosR8, .powerShotV10, .eosR5MARKII, .eosR1:
             return true
         case .eosR50V:
             return false
@@ -53,9 +62,11 @@ enum CameraType: String, CaseIterable {
     /// Image Operations API 버전
     var imageOperationsVersion: VersionType {
         switch self {
-        case .eosR50, .eosR6MarkII:
+        case .eos1DXMarkIII, .eosR5, .eosR6, .eosR3, .eosR7:
+            return .ver110
+        case .eosR50, .eosR6MarkII, .eosR8, .powerShotV10:
             return .ver120
-        case .eosR50V:
+        case .eosR50V, .eosR5MARKII, .eosR1:
             return .ver140
         }
     }
@@ -63,7 +74,7 @@ enum CameraType: String, CaseIterable {
     /// Event Monitor API 버전
     var eventMonitorVersion: VersionType {
         switch self {
-        case .eosR50, .eosR6MarkII, .eosR50V:
+        case .eos1DXMarkIII, .eosR1, .eosR5, .eosR6, .eosR3, .eosR7, .eosR8, .eosR50, .powerShotV10, .eosR5MARKII, .eosR6MarkII, .eosR50V:
             return .ver100
         }
     }
@@ -71,7 +82,7 @@ enum CameraType: String, CaseIterable {
     /// Shooting Control API 버전
     var shootingControlVersion: VersionType {
         switch self {
-        case .eosR50, .eosR6MarkII, .eosR50V:
+        case .eos1DXMarkIII, .eosR1, .eosR5, .eosR6, .eosR3, .eosR7, .eosR8, .powerShotV10, .eosR5MARKII, .eosR50, .eosR6MarkII, .eosR50V:
             return .ver100
         }
     }

--- a/HonestHouse/HonestHouse/Sources/Type/CameraType.swift
+++ b/HonestHouse/HonestHouse/Sources/Type/CameraType.swift
@@ -1,0 +1,96 @@
+//
+//  CameraType.swift
+//  HonestHouse
+//
+//  Created by BoMin Lee on 11/7/25.
+//
+
+import Foundation
+
+enum CameraType: String, CaseIterable {
+    case eosR50 = "EOS R50"
+    case eosR50V = "EOS R50V"
+    case eosR6MarkII = "EOS R6 Mark II"
+        
+    var displayName: String {
+        return rawValue
+    }
+    
+    private static let userDefaultsKey = "connectedCameraType"
+    
+    /// 현재 연결된 카메라 타입을 UserDefaults에서 불러오기
+    static var current: CameraType? {
+        get {
+            guard let rawValue = UserDefaults.standard.string(forKey: userDefaultsKey) else {
+                return nil
+            }
+            return CameraType(rawValue: rawValue)
+        }
+        set {
+            if let newValue = newValue {
+                UserDefaults.standard.set(newValue.rawValue, forKey: userDefaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+            }
+        }
+    }
+    
+    /// UserDefaults에서 카메라 타입 제거
+    static func clearCurrent() {
+        UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+    }
+    
+    /// 모드 다이얼 유무
+    var hasShootingModeDial: Bool {
+        switch self {
+        case .eosR50, .eosR6MarkII:
+            return true
+        case .eosR50V:
+            return false
+        }
+    }
+    
+    /// Image Operations API 버전
+    var imageOperationsVersion: VersionType {
+        switch self {
+        case .eosR50, .eosR6MarkII:
+            return .ver120
+        case .eosR50V:
+            return .ver140
+        }
+    }
+
+    /// Event Monitor API 버전
+    var eventMonitorVersion: VersionType {
+        switch self {
+        case .eosR50, .eosR6MarkII, .eosR50V:
+            return .ver100
+        }
+    }
+
+    /// Shooting Control API 버전
+    var shootingControlVersion: VersionType {
+        switch self {
+        case .eosR50, .eosR6MarkII, .eosR50V:
+            return .ver100
+        }
+    }
+
+    /// Shooting Settings API별 버전 반환
+    func shootingSettingsVersion(for api: ShootingSettingsAPI) -> VersionType {
+        switch self {
+        case .eosR50V:
+            // R50V는 shooting mode만 ver110, 나머지는 ver100
+            switch api {
+            case .shootingMode:
+                return .ver110
+            default:
+                return .ver100
+            }
+
+        // 다른 카메라들은 모든 Shooting Settings API가 ver100
+        default:
+            return .ver100
+        }
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/Type/CameraType.swift
+++ b/HonestHouse/HonestHouse/Sources/Type/CameraType.swift
@@ -8,18 +8,18 @@
 import Foundation
 
 enum CameraType: String, CaseIterable {
-    case eos1DXMarkIII = "EOS-1D X Mark III"
-    case eosR5 = "EOS R5"
-    case eosR6 = "EOS R6"
-    case eosR3 = "EOS R3"
-    case eosR7 = "EOS R7"
-    case eosR6MarkII = "EOS R6 Mark II"
-    case eosR8 = "EOS R8"
-    case eosR50 = "EOS R50"
-    case powerShotV10 = "PowerShot V10"
-    case eosR5MARKII = "EOS R5 Mark II"
+    case eos1DXMarkIII = "Canon EOS-1D X Mark III"
+    case eosR5 = "Canon EOS R5"
+    case eosR6 = "Canon EOS R6"
+    case eosR3 = "Canon EOS R3"
+    case eosR7 = "Canon EOS R7"
+    case eosR6MarkII = "Canon EOS R6 Mark II"
+    case eosR8 = "Canon EOS R8"
+    case eosR50 = "Canon EOS R50"
+    case powerShotV10 = "Canon PowerShot V10"
+    case eosR5MARKII = "Canon EOS R5 Mark II"
     case eosR1 = "EOS R1"
-    case eosR50V = "EOS R50V"
+    case eosR50V = "Canon EOS R50 V"
         
     var displayName: String {
         return rawValue
@@ -52,9 +52,9 @@ enum CameraType: String, CaseIterable {
     /// 모드 다이얼 유무
     var hasShootingModeDial: Bool {
         switch self {
-        case .eosR50, .eosR6MarkII, .eos1DXMarkIII, .eosR5, .eosR6, .eosR3, .eosR7, .eosR8, .powerShotV10, .eosR5MARKII, .eosR1:
+        case .eosR50, .eosR6MarkII, .eosR6, .eosR8:
             return true
-        case .eosR50V:
+        case .eosR50V, .eosR1, .eosR5MARKII, .powerShotV10, .eosR7, .eosR3, .eosR5, .eos1DXMarkIII:
             return false
         }
     }

--- a/HonestHouse/HonestHouse/Sources/Type/VersionType.swift
+++ b/HonestHouse/HonestHouse/Sources/Type/VersionType.swift
@@ -12,6 +12,7 @@ enum VersionType {
     case ver110
     case ver120
     case ver130
+    case ver140
     
     var description: String {
         switch self {
@@ -23,6 +24,8 @@ enum VersionType {
             return "ver120"
         case .ver130:
             return "ver130"
+        case .ver140:
+            return "ver140"
         }
     }
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #96 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- `CameraType` 생성
- `EventMonitorService`의 하드코딩된 `.ver100`을 `CameraType` 기반 동적 버전으로 변경
- `ImageOperationsService`의 `buildContentListURL`에서 하드코딩된 `.ver100`을 `CameraType` 기반으로 변경
- `ShootingControlTarget`에 `CameraType` 기반 버전 분기 적용
- `ShootingSettingsService` Protocol 및 구현체에서 불필요한 version 파라미터 제거
- `ShootingControlService` Protocol 및 구현체에서 불필요한 version 파라미터 제거
- `TrishotActivationViewModel`의 모든 API 호출에서 하드코딩된 버전 파라미터 제거
- `PresetViewModel`의 모든 API 호출에서 하드코딩된 버전 파라미터 제거

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] ShootingControl, ShootingSettings EOS R50V 정상 동작 확인
- [ ] ImageOperations 확인 필요
- [ ] R50 확인 필요

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

## 1. CameraType에 버전 속성 추가
새로운 CCAPI 카테고리를 추가할 경우, CameraType.swift에 해당 API의 버전 속성을 추가합니다.

```swift
/// [API 이름] API 버전
var [apiName]Version: VersionType {
    switch self {
    case .eosR50, .eosR6MarkII:
        return .ver100
    case .eosR50V:
        return .ver110  // 카메라별로 다른 버전 사용 시
    }
}
```

## 2. Target에서 CameraType 기반 버전 사용
BaseTargetType을 구현하는 Target에서 path를 동적으로 생성합니다.

```swift
var path: String {
    guard let cameraType = CameraType.current else {
        return defaultPath
    }

    let version = cameraType.[apiName]Version
    return [API].path(with: version)
}
```

```swift
private var defaultPath: String {
    // fallback 경로
    return [API].path(with: .ver100)
}
```

## 3. Service에서 version 파라미터 제거
Service Protocol과 구현체에서 `with version: VersionType` 파라미터를 사용하지 않습니다.
Target에서 자동으로 버전을 처리합니다.

## 4. ViewModel/Service 호출 시 버전 파라미터 제거
API 호출 시 버전을 명시하지 않습니다. CameraType이 자동으로 처리합니다.

## 그래서 앞으로는...
Camera 정보가 UserDefaults에 정상적으로 저장되지 않거나 할 때 발생할 수도 있는 문제 등에 대한 에러 처리가 필요합니다. 추후 이슈 발행해서 작업해볼게요!

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 연결된 카메라 모델 자동 감지·영구 저장 및 UI 동기화
  * 카메라별 API 버전(ver140 포함) 인식 지원

* **개선 사항**
  * 촬영 설정/제어 호출 단순화(버전 파라미터 제거)로 사용성·오류 식별 개선
  * 아카이브 경로·사진 URL 생성에 베이스 아카이브 URL 적용
  * 날짜 파싱 강화 및 HDR 메타데이터 수집으로 콘텐츠 신뢰도 향상
  * 이미지 목록/디렉터리 경로 처리 로직(버전별 분기) 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->