### PR TITLE
Design: #146 PresetGrid 간격 수정

### DIFF
--- a/HonestHouse/HonestHouse/Sources/Presentation/Main/View/MainView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Main/View/MainView.swift
@@ -20,7 +20,7 @@ struct MainView: View {
                 Color.g12.ignoresSafeArea(.all)
                 VStack(spacing: 12) {
                     headerView()
-                    VStack(spacing: 0) {
+                    VStack(spacing: vm.selectedSegment == .trishot ? 0 : 12){
                         CustomSegmentedControl(selection: $vm.selectedSegment)
                         selectedSegmentView()
                     }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
@@ -93,7 +93,6 @@ struct PresetView: View {
                 .matchedGeometryEffect(id: preset.id, in: namespace)
             }
         }
-        .padding(.top, 16)
     }
 
     private var listView: some View {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/View/PresetView.swift
@@ -62,10 +62,10 @@ struct PresetView: View {
     private var gridView: some View {
         LazyVGrid(
             columns: [
-                GridItem(.flexible(), spacing: 10),
-                GridItem(.flexible(), spacing: 10)
+                GridItem(.flexible(), spacing: 9),
+                GridItem(.flexible(), spacing: 9)
             ],
-            spacing: 10
+            spacing: 9
         ) {
             ForEach(vm.presets) { preset in
                 PresetGridItemView(


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #146 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- MainView에서 선택된 Segment에 따라 바뀌는 spacing을 분기 처리했습니다.
- PresetView의 Preset LazyVGrid의 spacing을 조정했습니다.
- PresetView의 Preset LazyVGrid의 불필요한 top padding을 제거했습니다.

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

|Preset List Border|Preset Grid Border|
|-----|-----|
|<img width="300" src="https://github.com/user-attachments/assets/bb8475ea-b8c5-4901-b481-2bdbd970fb79" />|<img width="300" src="https://github.com/user-attachments/assets/e2af3927-1752-454d-81a2-36db6e255b10" />|
---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] Simulator - iPhone 17 Pro, iOS 26.0.1 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->


---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일

* UI 레이아웃 간격 최적화
  * 특정 화면에서 컴포넌트 간 간격을 동적으로 조정하여 시각적 배치 개선
  * 그리드 뷰의 여백을 재조정하여 일관된 디자인 경험 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->