### PR TITLE
Refactor: #158 PhotoSelectionView 그리드 이미지가 빨리 뜨지 않는 문제 해결

### DIFF
--- a/HonestHouse/HonestHouse/Sources/Core/Managers/ImagePrefetchManager.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Managers/ImagePrefetchManager.swift
@@ -192,8 +192,8 @@ final class ImagePrefetchManager: ImagePrefetchManagerType {
             let interval: TimeInterval = {
                 switch priority {
                 case .high: return 0.0
-                case .medium: return 0.5
-                case .low: return 1.0
+                case .medium: return 0.3
+                case .low: return 0.2  // 1.0 → 0.2 (503 에러 방지하면서도 빠른 로딩)
                 }
             }()
 

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/GridCellView/GroupedPhotosGridCellView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/GridCellView/GroupedPhotosGridCellView.swift
@@ -29,7 +29,7 @@ struct GroupedPhotosGridCellView: View {
     }
     
     private func thumbnailView(for photo: Photo) -> some View {
-        CachedGridCellImageView(url: photo.displayURL, originalURL: photo.url)
+        CachedGridCellImageView(url: photo.displayURL, fallbackURL: photo.url)
             .overlay {
                 thumbnailBorder()
             }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/GridCellView/SelectionGridCellView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/GridCellView/SelectionGridCellView.swift
@@ -18,7 +18,7 @@ struct SelectionGridCellView: View {
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
             NavigationLink(destination: PhotoSelectionDetailView(initialPhoto: photo).environment(vm)) {
-                CachedGridCellImageView(url: photo.thumbnailURL, originalURL: photo.url)
+                CachedGridCellImageView(url: photo.thumbnailURL, fallbackURL: photo.thumbnailURL)
                     .overlay(
                         RoundedRectangle(cornerRadius: 8)
                             .strokeBorder(isSelected ? Color.yellow1 : Color.clear, lineWidth: 1)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/KingFisherView/CachedGridCellImageView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/KingFisherView/CachedGridCellImageView.swift
@@ -40,7 +40,6 @@ struct CachedGridCellImageView: View {
             .onFailure { _ in
                 shouldUseFallback = true
             }
-            .cacheOriginalImage()  // 디스크+메모리 캐싱
             .cacheOriginalImage()
             .fade(duration: 0.2)
             .resizable()

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/KingFisherView/CachedGridCellImageView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/KingFisherView/CachedGridCellImageView.swift
@@ -11,7 +11,7 @@ import Kingfisher
 /// 그리드, 그룹 대표 이미지 (GridCell)
 struct CachedGridCellImageView: View {
     let url: String
-    let originalURL: String
+    let fallbackURL: String
     
     @State private var shouldUseFallback = false
     
@@ -41,6 +41,7 @@ struct CachedGridCellImageView: View {
                 shouldUseFallback = true
             }
             .cacheOriginalImage()  // 디스크+메모리 캐싱
+            .cacheOriginalImage()
             .fade(duration: 0.2)
             .resizable()
             .scaledToFit()
@@ -48,7 +49,7 @@ struct CachedGridCellImageView: View {
     }
     
     private func fallbackImageView() -> some View {
-        KFImage(URL(string: originalURL))
+        KFImage(URL(string: fallbackURL))
             .placeholder {
                 Color.clear
             }
@@ -57,5 +58,6 @@ struct CachedGridCellImageView: View {
             .fade(duration: 0.2)
             .resizable()
             .scaledToFit()
+            .scaleEffect(1.12)
     }
 }

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/KingFisherView/ProgressiveDisplayImageView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/Component/KingFisherView/ProgressiveDisplayImageView.swift
@@ -14,7 +14,6 @@ struct ProgressiveDisplayImageView: View {
     
     let photo: Photo
     
-    
     var body: some View {
         Group {
             if shouldUseFallback {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Archive/ViewModel/PhotoSelectionViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Archive/ViewModel/PhotoSelectionViewModel.swift
@@ -144,28 +144,28 @@ final class PhotoSelectionViewModel {
         // ContentInfo 배치 처리
         await fetchContentInfoBatch(urls: uniqueUrls)
         
-        // Prefetch 시작 (첫 100장 도착 시)
-        if !hasStartedInitialPrefetch && allPhotos.count >= 100 {
+        // Prefetch 시작 (첫 20장 도착 시로 변경 - 503 에러 방지)
+        if !hasStartedInitialPrefetch && allPhotos.count >= 20 {
             hasStartedInitialPrefetch = true
             container.managers.imagePrefetchManager.startInitialPrefetch(
-                photos: allPhotos, count: 50
+                photos: allPhotos, count: 30
             )
         }
     }
     
     /// ContentInfo 배치 처리 (동시 요청 수 제한)
     private func fetchContentInfoBatch(urls: [String]) async {
-        let batchSize = 10
-        
+        let batchSize = 5  // 10 → 5 (503 에러 방지)
+
         // 100개를 batchSize씩 나눠서 순차 처리
         for i in stride(from: 0, to: urls.count, by: batchSize) {
             let end = min(i + batchSize, urls.count)
             let batch = Array(urls[i..<end])
-            
+
             await processBatch(batch)
-            
-            // 배치 간 짧은 지연 (네트워크 부하 방지)
-            try? await Task.sleep(nanoseconds: 50_000_000) // 0.05초
+
+            // 배치 간 지연 (ver140 카메라 503 에러 방지)
+            try? await Task.sleep(nanoseconds: 100_000_000) // 0.1초
         }
     }
     


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #158

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
### PhotoSelectionView에서 사용하는 캐싱 컴포넌트 뷰 및 viewmodel, manager 수정
1. low queue interval 수정: // 1.0 → 0.2 (503 에러 방지하면서도 빠른 로딩)
2. prefetch 시작을 첫 20장 도착 시로 변경
3. contentInfo 배치 처리를 10 -> 5로 변경
4. fallback시, thumbnail로 retry

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->
- 하이고... 어쨋든 dateInfo 받아오는 처리가 아주 조금이라도 더 늦어졌기 때문에 
현재, dateInfo 요청 및 날짜 section 구성을 병렬처리로 하고 있는데 더 빨리 할 수 있는 직렬 처리를 시도해서 이미지 로딩 후 나타날 시, 순차적으로 나타날 수 있게끔 처리해볼 예정입니다. (+ 뷰 나갔을 때 캐싱 없애서 기존에 있던 이미지 가끔 뜨는것도 리팩)
카메라 더 오면 주말에 도전 으하하
---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 이미지 미리 로드 간격 최적화로 더 빠른 로딩 속도 달성
  * 이미지 배치 처리 및 대기 시간 조정으로 서버 에러 완화

* **버그 수정**
  * 이미지 로드 실패 시 대체 이미지 처리 로직 개선
  * 여러 요청 처리 중 안정성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->