### PR TITLE
Design: #164 프리셋 없을 때 안내 문구 나오도록 수정

### DIFF
--- a/HonestHouse/HonestHouse/Sources/Presentation/Main/View/MainView.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Main/View/MainView.swift
@@ -31,6 +31,10 @@ struct MainView: View {
                     NavigationRoutingView(destination: $0)
                 }
 
+                if vm.selectedSegment == .preset && vm.presets.isEmpty {
+                    presetEmptyStateView
+                }
+
                 if vm.showModeChange {
                     Color.clear
                         .contentShape(Rectangle())
@@ -166,6 +170,41 @@ struct MainView: View {
         } else if vm.selectedSegment == .preset {
             PresetView(vm: vm)
         }
+    }
+
+    private var presetEmptyStateView: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            HStack(spacing: 0) {
+                Text("하단의")
+                    .fontStyle(.num4)
+                    .foregroundStyle(Color.g9)
+                    .padding(.trailing, 8)
+                Image(.plus)
+                    .resizable()
+                    .renderingMode(.template)
+                    .scaledToFit()
+                    .frame(width: 12, height: 12)
+                    .foregroundStyle(Color.g9)
+                    .padding(2.5)
+                    .overlay(
+                        Circle()
+                            .strokeBorder(Color.g9, lineWidth: 1)
+                    )
+                Text("버튼을 눌러")
+                    .fontStyle(.num4)
+                    .foregroundStyle(Color.g9)
+                    .padding(.leading, 4)
+            }
+
+            Text("Preset을 생성해보세요!")
+                .fontStyle(.num4)
+                .foregroundStyle(Color.g9)
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .allowsHitTesting(false)
     }
 }
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #164 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 프리셋 없을 때 안내 문구 나오도록 수정

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

|프리셋 없을 때|
|-----|
|<img width="300" src="https://github.com/user-attachments/assets/f6cb14d5-bf2e-4c64-80cc-6bbb26a07b01" />|

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15 pro, iOS 26.0.1 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->



---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 프리셋이 없을 때 프리셋 탭에 빈 상태 화면을 표시합니다. 프리셋을 생성하도록 안내하는 메시지와 힌트를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->