### PR TITLE
Refactor: #171 프리셋 생성 후 복귀 시 바로 load되지 않는 문제 해결

### DIFF
--- a/HonestHouse/HonestHouse/Sources/Core/Managers/PresetStateObserver.swift
+++ b/HonestHouse/HonestHouse/Sources/Core/Managers/PresetStateObserver.swift
@@ -1,0 +1,17 @@
+//
+//  PresetStateObserver.swift
+//  HonestHouse
+//
+//  Created by BoMin Lee on 11/25/25.
+//
+
+import Foundation
+import Combine
+
+final class PresetStateObserver: ObservableObject {
+    @Published var didChange: Bool = false
+
+    func notifyPresetChanged() {
+        didChange.toggle()
+    }
+}

--- a/HonestHouse/HonestHouse/Sources/General/DIContainer.swift
+++ b/HonestHouse/HonestHouse/Sources/General/DIContainer.swift
@@ -11,14 +11,17 @@ class DIContainer: ObservableObject {
     var services: ServiceType
     var managers: ManagersType
     var navigationRouter: NavigationRoutable & ObservableObjectSettable
+    var presetStateObserver: PresetStateObserver
     
     init(
         services: ServiceType,
         managers: ManagersType,
-        navigationRouter: NavigationRoutable & ObservableObjectSettable = NavigationRouter()
+        navigationRouter: NavigationRoutable & ObservableObjectSettable = NavigationRouter(),
+        presetStateObserver: PresetStateObserver = PresetStateObserver()
     ) {
         self.services = services
         self.managers = managers
+        self.presetStateObserver = presetStateObserver
         
         self.navigationRouter = navigationRouter
         self.navigationRouter.setObjectWillChange(objectWillChange)

--- a/HonestHouse/HonestHouse/Sources/Presentation/Main/ViewModel/MainViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Main/ViewModel/MainViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 
 enum MainAction {
     case goToPresetEditor(PresetDetailViewMode, Preset?)
@@ -16,6 +17,7 @@ enum MainAction {
 @Observable
 final class MainViewModel {
     private let container: DIContainer
+    private var cancellables = Set<AnyCancellable>()
 
     var selectedSegment: MainViewSegmentType = .trishot
     var segments: [MainViewSegmentType] = [.trishot, .preset]
@@ -38,6 +40,15 @@ final class MainViewModel {
     
     init(container: DIContainer) {
         self.container = container
+        observePresetChanges()
+    }
+    
+    private func observePresetChanges() {
+        container.presetStateObserver.$didChange
+            .sink { [weak self] _ in
+                self?.loadPresets()
+            }
+            .store(in: &cancellables)
     }
     
     func send(action: MainAction) {
@@ -108,9 +119,11 @@ final class MainViewModel {
                 try container.managers.presetManager.deletePreset(by: id)
             }
             selectedPresets.removeAll()
-            loadPresets()
             showDeleteAlert = false
             exitEditMode()
+            
+            // 프리셋 변경 알림 (observePresetChanges가 자동으로 loadPresets 호출)
+            container.presetStateObserver.notifyPresetChanged()
         } catch let presetManagerError as PresetManagerError {
             currentError = PresetError.fromPresetManager(presetManagerError)
         } catch let presetError as PresetError {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Preset/ViewModel/PresetDetailViewModel.swift
@@ -225,6 +225,9 @@ class PresetDetailViewModel {
             // 성공 시 View 모드로 전환
             switchToViewMode()
 
+            // 프리셋 변경 알림
+            container.presetStateObserver.notifyPresetChanged()
+            
         } catch {
             throw error
         }
@@ -259,6 +262,10 @@ class PresetDetailViewModel {
         do {
             try container.managers.presetManager.deletePreset(by: currentPreset.id)
             Logger.info("Preset deleted successfully: \(currentPreset.id)", category: .preset)
+            
+            // 프리셋 변경 알림
+            container.presetStateObserver.notifyPresetChanged()
+            
             // 삭제 성공 시 PresetView로 이동
             send(.popToPresetView)
         } catch let presetManagerError as PresetManagerError {

--- a/HonestHouse/HonestHouse/Sources/Presentation/Trishot/ViewModel/TrishotSettingViewModel.swift
+++ b/HonestHouse/HonestHouse/Sources/Presentation/Trishot/ViewModel/TrishotSettingViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 import CoreData
+import Combine
 
 enum TrishotSettingAction {
     case goToTrishotSelection(order: Int)
@@ -18,12 +19,14 @@ enum TrishotSettingAction {
 @Observable
 final class TrishotSettingViewModel {
     private let container: DIContainer
+    private var cancellables = Set<AnyCancellable>()
 
     var allSelectedPresets: [Preset] = []
 
     init(container: DIContainer) {
         self.container = container
         loadPresets()
+        observePresetChanges()
     }
 
     func loadPresets() {
@@ -32,6 +35,14 @@ final class TrishotSettingViewModel {
         } catch {
             Logger.error("Failed to load selected presets: \(error.localizedDescription)", category: .trishot)
         }
+    }
+
+    private func observePresetChanges() {
+        container.presetStateObserver.$didChange
+            .sink { [weak self] _ in
+                self?.loadPresets()
+            }
+            .store(in: &cancellables)
     }
 }
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #이슈번호

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 프리셋을 생성한 후 `PresetView`나 `TrishotSettingView`로 돌아와도 목록이 자동으로 갱신되지 않는 문제 해결
---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] iPhone 15 pro, iOS 26.0.1 환경에서 정상 동작

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

#### 1. PresetStateObserver 추가
프리셋 변경을 전역적으로 감지할 수 있는 Observer 패턴 구현

```swift
final class PresetStateObserver: ObservableObject {
    @Published var didChange: Bool = false
    func notifyPresetChanged() {
        didChange.toggle()
    }
}
```

#### 2. viewModel에서 구독
Combine을 사용해 프리셋 변경 감지 및 자동 갱신

```swift
private var cancellables = Set<AnyCancellable>()
private func observePresetChanges() {
    container.presetStateObserver.$didChange
    .sink { [weak self] _ in
        self?.loadPresets()
    }
    .store(in: &cancellables)
}
```


#### 3. 변경 알림 트리거
프리셋 생성/수정/삭제 시 observer에 알림

```swift
func savePreset() async throws {
    container.presetStateObserver.notifyPresetChanged()
}
```
---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 프리셋 저장, 삭제 시 자동으로 데이터를 새로고침하도록 개선
  * 프리셋 변경 사항이 실시간으로 반영되어 사용자 경험 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->